### PR TITLE
Shared TAP networking and better multiple VM mouse support by defaulting to SDL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 
 Introduction
 ------------
-This project provides a set of scripts to simplify the setup and management of classic Macintosh (m68k architecture) emulation using QEMU. It allows you to define different Mac OS configurations in separate files and easily launch them, while also providing a utility to share files between your host Linux system and the emulated Mac environment via a shared disk image.
+This project provides a set of scripts to simplify the setup and management of classic Macintosh (m68k architecture) emulation using QEMU. It allows you to define different Mac OS configurations in separate files and easily launch them. Key features include automatic setup of bridged networking for inter-VM communication and a utility to share files between your host Linux system and the emulated Mac environment via a shared disk image.
 
 Purpose
 -------
 - To provide a consistent and repeatable way to launch QEMU for specific Mac models and OS versions.
 - To manage separate disk images (OS, shared data, PRAM) for different configurations.
+- To automatically configure TAP networking, enabling direct communication (AppleTalk, TCP/IP) between multiple running VM instances.
 - To simplify the process of booting from CD/ISO images for OS installation.
 - To offer a convenient method (`mac_disc_mounter.sh`) for accessing a shared disk image from the Linux host for file transfer.
 
@@ -16,15 +17,19 @@ Prerequisites
 -------------
 1.  **QEMU:** You need the `qemu-system-m68k` package installed.
     - On Debian/Ubuntu: `sudo apt update && sudo apt install qemu-system-m68k`
-2.  **Macintosh ROM Files:** You MUST obtain the correct ROM file(s) for the Macintosh model(s) you wish to emulate (e.g., `800.ROM` for a Quadra 800).
+2.  **Networking Utilities:** For the automatic network setup, you need `bridge-utils` and `iproute2` (usually installed by default).
+    - On Debian/Ubuntu: `sudo apt update && sudo apt install bridge-utils`
+    - The script will check for `brctl` and prompt if `bridge-utils` is missing.
+3.  **Sudo Privileges:** The `run68k.sh` script now requires `sudo` privileges to create and manage the network bridge and TAP interfaces. You will likely be prompted for your password when launching a VM.
+4.  **Macintosh ROM Files:** You MUST obtain the correct ROM file(s) for the Macintosh model(s) you wish to emulate (e.g., `800.ROM` for a Quadra 800).
     - **IMPORTANT:** ROM files are copyrighted software and are NOT included with this project. You must acquire them legally (e.g., dump them from your own physical hardware). Place the ROM file(s) where the configuration files expect them (or update the paths in the `.conf` files). You can often find ROM files online. A common source is [Macintosh Repository](https://www.macintoshrepository.org/7038-all-macintosh-roms-68k-ppc-)
-3.  **Mac OS Installation Media:** You need CD-ROM images (.iso, .img, .toast) or floppy disk images for the version(s) of Mac OS you intend to install. These are also NOT included. I use the Apple Legacy Software Recovery CD from  [Macintosh Garden](https://macintoshgarden.org/apps/apple-legacy-software-recovery-cd)
-4.  **Linux Host:** The `mac_disc_mounter.sh` script is specifically designed for Linux systems (using `apt` for package management and standard mount commands). The `run68k.sh` script might work on other Unix-like systems (like macOS) with potential minor adjustments (e.g., display type).
-5.  **(For `mac_disc_mounter.sh`) HFS/HFS+ Utilities:** The mounting script requires `hfsprogs` and `hfsplus` to interact with Mac-formatted disk images. The script will attempt to install these automatically using `sudo apt-get install` if they are not found.
+5.  **Mac OS Installation Media:** You need CD-ROM images (.iso, .img, .toast) or floppy disk images for the version(s) of Mac OS you intend to install. These are also NOT included. I use the Apple Legacy Software Recovery CD from [Macintosh Garden](https://macintoshgarden.org/apps/apple-legacy-software-recovery-cd)
+6.  **Linux Host:** The `mac_disc_mounter.sh` script is specifically designed for Linux systems (using `apt` for package management and standard mount commands). The `run68k.sh` script is tested on Ubuntu but might work on other Unix-like systems (like macOS) with potential minor adjustments (e.g., display type, network setup commands).
+7.  **(For `mac_disc_mounter.sh`) HFS/HFS+ Utilities:** The mounting script requires `hfsprogs` and `hfsplus` to interact with Mac-formatted disk images. The script will attempt to install these automatically using `sudo apt-get install` if they are not found.
 
 File Structure
 --------------
-- `run68k.sh`: The main script to launch the QEMU emulator.
+- `run68k.sh`: The main script to launch the QEMU emulator with network setup.
 - `mac_disc_mounter.sh`: Utility script to mount/unmount the shared disk image on the Linux host.
 - `*.conf`: Configuration files defining specific emulation setups (e.g., `sys755-q800.conf`).
 - `*.ROM`: (User-provided) Macintosh ROM files.
@@ -44,12 +49,17 @@ These files define the parameters for a specific emulation instance using shell 
 - `QEMU_HDD_SIZE`: (Optional) Size for the OS HDD if it needs to be created (default: 1G).
 - `QEMU_SHARED_HDD_SIZE`: (Optional) Size for the Shared HDD if it needs to be created (default: 200M).
 - `QEMU_CPU`: (Optional) Specify a specific CPU variant if needed.
+- `BRIDGE_NAME`: (Optional) Name of the host network bridge to use (default: `br0`).
+- `QEMU_TAP_IFACE`: (Optional) Specify a fixed name for the VM's TAP network interface. If omitted, a unique name is generated based on the config filename (e.g., `tap_sys755q800`).
+- `QEMU_MAC_ADDR`: (Optional) Specify a fixed MAC address for the VM's network interface. If omitted, a unique QEMU MAC address is generated.
 
 You can create new `.conf` files for different Mac OS versions, machine types, or experimental setups. Ensure the paths point to unique locations if you want separate installations.
 
 Usage: `run68k.sh`
 -------------------
-This script launches the QEMU emulator based on a specified configuration file.
+This script launches the QEMU emulator based on a specified configuration file and sets up TAP networking.
+
+**IMPORTANT:** This script now requires `sudo` privileges to manage network interfaces.
 
 **Syntax:**
 `./run68k.sh -C <config_file.conf> [options]`
@@ -60,18 +70,43 @@ This script launches the QEMU emulator based on a specified configuration file.
 **Options:**
 - `-c FILE`: Specify a CD-ROM image file (.iso, .img) to attach to the emulator. *Note this is little c not big C.*
 - `-b`: Boot from the attached CD-ROM (requires the `-c` option). Use this for OS installation.
-- `-d TYPE`: Force a specific QEMU display type (`sdl`, `gtk`, `cocoa`). If omitted, it attempts to auto-detect (cocoa for macOS, sdl otherwise).
+- `-d TYPE`: Force a specific QEMU display type (`sdl`, `gtk`, `cocoa`). If omitted, it attempts to auto-detect (cocoa for macOS, sdl for Linux/other).
 - `-?`: Show help message.
 
 **Examples:**
 
 1.  **Run an existing System 7.5.5 installation:**
     `./run68k.sh -C sys755-q800.conf`
+    *(You will likely be prompted for your sudo password for network setup)*
 
 2.  **Boot from a System 7.6.1 install CD to install the OS:**
     `./run68k.sh -C sys761-q800.conf -c /path/to/your/Mac_OS_7.6.1.iso -b`
     *(will create `761/hdd_sys761.img`, `761/shared_761.img`, and `761/pram_761_q800.img` if they don't exist)*
     *You will need to use Drive Setup to format the disks on first boot before installing an OS*
+
+Networking Setup (Automatic)
+----------------------------
+The `run68k.sh` script now automatically configures networking to allow communication between multiple running VM instances.
+
+**How it Works:**
+1.  **Bridge Creation:** The script ensures a network bridge (default name `br0`, configurable via `BRIDGE_NAME` in `.conf`) exists on the host system. If not, it creates it using `sudo ip link`.
+2.  **TAP Interface Creation:** For each VM instance launched, the script creates a dedicated virtual network interface called a TAP device (e.g., `tap_sys755q800`) using `sudo ip tuntap`. This TAP device is owned by the user running the script.
+3.  **Connecting TAP to Bridge:** The script brings the TAP interface up and connects it to the network bridge using `sudo brctl addif`.
+4.  **QEMU Connection:** QEMU is configured to use this specific TAP device (`-netdev tap,... -net nic,...`) instead of the simpler (but isolated) `-net user`.
+5.  **Cleanup:** When the script exits (normally or via Ctrl+C), it automatically attempts to remove the TAP device from the bridge and delete the TAP device using `sudo`.
+
+**Benefits:**
+- VMs connected to the same bridge can communicate directly using protocols like AppleTalk (for classic file sharing, printers) and TCP/IP (if configured).
+- This allows you to run multiple Mac OS VMs simultaneously and have them interact as if they were on the same physical Ethernet network.
+
+**In-VM Configuration:**
+- After launching the VM, you need to configure networking *inside* the emulated Mac OS:
+    - **Control Panels:** Use the `MacTCP` or `TCP/IP` (Open Transport) control panel.
+    - **Connection Method:** Select `Ethernet`.
+    - **IP Address:** You can often use `DHCP` if you have a DHCP server running on your host or LAN accessible via the bridge. Otherwise, assign static IP addresses manually within the same subnet for each VM (e.g., `192.168.100.1`, `192.168.100.2`, with subnet mask `255.255.255.0`). Ensure these IPs don't conflict with other devices if your bridge is connected to your main LAN.
+    - **AppleTalk:** Use the `AppleTalk` control panel and ensure it's set to `Active` and connected via `Ethernet`. VMs on the same bridge should then see each other in the Chooser for file sharing.
+
+**Note:** This setup primarily enables VM-to-VM communication. Connecting VMs to your wider LAN or the internet requires additional host configuration (e.g., adding the host's physical interface to the bridge, setting up IP forwarding/NAT on the host) which is beyond the scope of this script's automatic setup.
 
 Usage: `mac_disc_mounter.sh` (Linux Only)
 -----------------------------------------
@@ -113,19 +148,20 @@ This script mounts or unmounts the *shared* disk image associated with a specifi
 
 Getting Started / First OS Installation
 ---------------------------------------
-1.  **Install Prerequisites:** Ensure QEMU is installed.
+1.  **Install Prerequisites:** Ensure QEMU and `bridge-utils` are installed.
 2.  **Obtain ROM:** Get the correct ROM file (e.g., `800.ROM`) and place it where the `.conf` file expects it (e.g., in the same directory as the scripts, or update the `QEMU_ROM` path in the `.conf` file).
 3.  **Obtain Install Media:** Get the Mac OS install CD/ISO image.
 4.  **Choose Config:** Select a `.conf` file corresponding to the OS you want to install (e.g., `sys761-q800.conf`).
 5.  **Run Installer:** Execute `run68k.sh` with the `-c` (CD image) and `-b` (boot from CD) flags:
     `./run68k.sh -C sys761-q800.conf -c /path/to/your/Mac_OS_7.6.1.iso -b`
-    *(The script will create the necessary directories and empty disk image files specified in the config if they don't exist)*
+    *(The script will prompt for sudo password, create network interfaces, and create necessary directories/empty disk images if they don't exist)*
 6.  **Install OS:** Inside the QEMU window, follow the standard Mac OS installation procedure. You will need to initialize/format the virtual hard disk (`QEMU_HDD`) using a tool like "Drive Setup" or "Apple HD SC Setup" from the installer before you can install onto it.
 7.  **(Optional) Format Shared Disk:** While the installer is running (or after installation), you can also format the *shared* disk (`QEMU_SHARED_HDD`) using Drive Setup so it's ready for file transfer later. Format it as HFS or HFS+.
 8.  **Shutdown:** Once installation is complete, shut down the emulated Mac.
 9.  **First Boot from HDD:** Run the script *without* the `-c` and `-b` flags to boot from the newly installed OS on the virtual hard disk:
     `./run68k.sh -C sys761-q800.conf`
-10. **File Transfer:**
+10. **Configure Networking (Inside VM):** Set up MacTCP/TCP/IP and AppleTalk control panels as described in the "Networking Setup" section if you want network connectivity.
+11. **File Transfer:**
     - Shut down the emulated Mac.
     - Mount the shared disk on your Linux host: `sudo ./mac_disc_mounter.sh -C sys761-q800.conf`
     - Copy files to/from the mount point (e.g., `/mnt/mac_shared`).
@@ -135,7 +171,7 @@ Getting Started / First OS Installation
 Important Notes
 ---------------
 - **ROM Legality:** Remember, you are responsible for legally obtaining any Macintosh ROM files.
-- **Permissions:** You may need `sudo` for `mac_disc_mounter.sh`. Ensure you have write permissions in the directories where disk images will be created by `run68k.sh`.
+- **Permissions:** `run68k.sh` requires `sudo` for networking. `mac_disc_mounter.sh` also requires `sudo`. Ensure you have write permissions in the directories where disk images will be created by `run68k.sh`.
 - **Shared Disk Formatting:** The shared disk image needs to be formatted *inside* the emulated Mac OS before `mac_disc_mounter.sh` can successfully mount it for read/write access on the host.
 - **VM Shutdown:** Always shut down the QEMU virtual machine cleanly before attempting to mount its shared disk image on the host.
 
@@ -143,5 +179,7 @@ Troubleshooting
 ---------------
 - **"ROM file ... not found"**: Verify the `QEMU_ROM` path in your `.conf` file is correct and the ROM file exists at that location.
 - **"Failed to create directory/image"**: Check filesystem permissions for the directories specified in the `.conf` file paths (`QEMU_HDD`, `QEMU_SHARED_HDD`, `QEMU_PRAM`).
-- **QEMU display issues**: If the default display (`sdl` or `cocoa`) doesn't work, try forcing another type with `-d gtk` or `-d sdl`. Ensure necessary host libraries (like SDL or GTK development headers) are installed.
+- **Network Errors ("Failed to create bridge/TAP", "Failed to add TAP to bridge")**: Ensure `bridge-utils` is installed. Check `sudo` permissions. Make sure the bridge name (`br0`) or TAP name doesn't conflict with existing interfaces managed outside this script. Check system logs (`dmesg`, `journalctl`) for more details.
+- **VMs Cannot See Each Other:** Verify both VMs are running and connected to the *same* bridge (`br0` by default). Check the MacTCP/TCP/IP settings inside each VM (ensure they are on the same subnet if using static IPs). Check AppleTalk control panel settings (Ethernet, Active).
+- **QEMU display issues**: If the default display (`sdl` or `cocoa`) doesn't work well (e.g., mouse problems), try forcing another type with `-d gtk` (if available) or `-d sdl`. Ensure necessary host libraries (like SDL or GTK development headers) are installed.
 - **Cannot mount shared disk**: Ensure the VM is shut down. Ensure the disk was formatted inside the VM. Try the check (`-c`) or repair (`-r`) options with `mac_disc_mounter.sh`. Check system logs (`dmesg`) for mount errors.

--- a/run68k.sh
+++ b/run68k.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # Script to run Mac OS emulation using QEMU with configuration files
+# Updated to use TAP networking via a bridge for inter-VM communication
+# Defaults to SDL display on Linux/non-macOS systems
 
 # --- Configuration variables (will be loaded from .conf file) ---
 CONFIG_NAME=""
@@ -14,29 +16,149 @@ QEMU_GRAPHICS=""
 QEMU_CPU=""               # Optional CPU override
 QEMU_HDD_SIZE="1G"        # Default size for OS HDD if created
 QEMU_PRAM=""              # Path to the PRAM image file (now from config)
+BRIDGE_NAME="br0"         # Default bridge name (can be overridden in config)
+QEMU_TAP_IFACE=""         # Optional: Specific TAP interface name (generated if empty)
+QEMU_MAC_ADDR=""          # Optional: Specific MAC address (generated if empty)
 
 # --- Script variables ---
 CONFIG_FILE=""
 CD_FILE=""                # Path to CD/ISO image
 BOOT_FROM_CD=false
 DISPLAY_TYPE=""           # Auto-detect later if not specified
+TAP_DEV_NAME=""           # Actual TAP device name used for this instance
+MAC_ADDRESS=""            # Actual MAC address used
 
 # Display help information
 show_help() {
     echo "Usage: $0 -C <config_file.conf> [options]"
     echo "Required:"
     echo "  -C FILE  Specify configuration file (e.g., sys755-q800.conf)"
-    echo "           The config file defines the machine, RAM, ROM, OS HDD, Shared HDD, and PRAM file."
+    echo "           The config file defines machine, RAM, ROM, disks, PRAM, graphics,"
+    echo "           and optionally BRIDGE_NAME, QEMU_TAP_IFACE, QEMU_MAC_ADDR."
     echo "Options:"
     echo "  -c FILE  Specify CD-ROM image file (if not specified, no CD will be attached)"
     echo "  -b       Boot from CD-ROM (requires -c option)"
     echo "  -d TYPE  Force display type (sdl, gtk, cocoa)"
     echo "  -?       Show this help message"
+    echo "Networking:"
+    echo "  This script sets up TAP networking via a bridge (default: br0)."
+    echo "  Requires 'bridge-utils' package and sudo privileges."
     exit 1
 }
 
-# Parse command-line arguments
-# Removed -p option as PRAM is now defined in the config file
+# --- Helper Functions ---
+
+# Function to check for required commands
+check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        echo "Error: Command '$1' not found."
+        if [ "$1" == "brctl" ]; then
+            echo "Please install 'bridge-utils': sudo apt update && sudo apt install bridge-utils"
+        fi
+        exit 1
+    fi
+}
+
+# Function to generate a random MAC address if not provided
+generate_mac() {
+    hexchars="0123456789ABCDEF"
+    # QEMU MAC prefix 52:54:00
+    echo "52:54:00:$(for i in {1..6} ; do echo -n ${hexchars:$(( $RANDOM % 16 )):1} ; done | sed -e 's/\(..\)/\1:/g' -e 's/:$//')"
+}
+
+# Function to set up the network bridge
+setup_bridge() {
+    local bridge="$1"
+    echo "--- Network Setup ---"
+    echo "Ensuring bridge '$bridge' exists and is up..."
+    if ! ip link show "$bridge" &> /dev/null; then
+        echo "Bridge '$bridge' not found. Creating..."
+        sudo ip link add name "$bridge" type bridge
+        if [ $? -ne 0 ]; then echo "Error: Failed to create bridge '$bridge'."; exit 1; fi
+        echo "Bringing bridge '$bridge' up..."
+        sudo ip link set "$bridge" up
+        if [ $? -ne 0 ]; then echo "Error: Failed to bring up bridge '$bridge'."; exit 1; fi
+        echo "Bridge '$bridge' created and up."
+    else
+        # Ensure bridge is up even if it exists
+        if ! ip link show "$bridge" | grep -q "state UP"; then
+             echo "Bridge '$bridge' exists but is down. Bringing up..."
+             sudo ip link set "$bridge" up
+             if [ $? -ne 0 ]; then echo "Error: Failed to bring up bridge '$bridge'."; exit 1; fi
+        else
+             echo "Bridge '$bridge' already exists and is up."
+        fi
+    fi
+    echo "---------------------"
+}
+
+# Function to set up the TAP interface for the VM
+# Takes TAP name and Bridge name as arguments
+setup_tap() {
+    local tap_name="$1"
+    local bridge_name="$2"
+    local current_user=$(whoami)
+
+    echo "--- Network Setup ---"
+    echo "Setting up TAP interface '$tap_name' for user '$current_user'..."
+
+    # Check if TAP device already exists (maybe from a crashed previous run)
+    if ip link show "$tap_name" &> /dev/null; then
+        echo "Warning: TAP device '$tap_name' already exists. Trying to reuse/reconfigure."
+        # Ensure it's down before potential deletion or reconfiguration
+        sudo ip link set "$tap_name" down &> /dev/null
+        # Attempt to remove from bridge just in case it's stuck
+        sudo brctl delif "$bridge_name" "$tap_name" &> /dev/null
+    fi
+
+    echo "Creating TAP device '$tap_name'..."
+    sudo ip tuntap add dev "$tap_name" mode tap user "$current_user"
+    if [ $? -ne 0 ]; then echo "Error: Failed to create TAP device '$tap_name'."; exit 1; fi
+
+    echo "Bringing TAP device '$tap_name' up..."
+    sudo ip link set "$tap_name" up
+    if [ $? -ne 0 ]; then echo "Error: Failed to bring up TAP device '$tap_name'."; sudo ip tuntap del dev "$tap_name" mode tap; exit 1; fi
+
+    echo "Adding TAP device '$tap_name' to bridge '$bridge_name'..."
+    sudo brctl addif "$bridge_name" "$tap_name"
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to add TAP device '$tap_name' to bridge '$bridge_name'."
+        sudo ip link set "$tap_name" down
+        sudo ip tuntap del dev "$tap_name" mode tap
+        exit 1
+    fi
+
+    echo "TAP device '$tap_name' is up and added to bridge '$bridge_name'."
+    echo "---------------------"
+}
+
+# Function to clean up the TAP interface
+# Takes TAP name and Bridge name as arguments
+cleanup_tap() {
+    local tap_name="$1"
+    local bridge_name="$2"
+    echo # Newline for clarity after QEMU exits
+    echo "--- Network Cleanup ---"
+    echo "Cleaning up TAP interface '$tap_name'..."
+
+    # Check if the interface exists before trying to manipulate it
+    if ip link show "$tap_name" &> /dev/null; then
+        echo "Removing TAP device '$tap_name' from bridge '$bridge_name'..."
+        sudo brctl delif "$bridge_name" "$tap_name"
+        # Don't exit on error here, proceed to bring down and delete
+
+        echo "Bringing TAP device '$tap_name' down..."
+        sudo ip link set "$tap_name" down
+
+        echo "Deleting TAP device '$tap_name'..."
+        sudo ip tuntap del dev "$tap_name" mode tap
+    else
+        echo "TAP device '$tap_name' not found, cleanup skipped."
+    fi
+    echo "-----------------------"
+}
+
+# --- Argument Parsing ---
 while getopts "C:c:bd:?" opt; do
     case $opt in
         C) CONFIG_FILE="$OPTARG" ;;
@@ -49,6 +171,14 @@ done
 
 # --- Validation and Configuration Loading ---
 
+# Check required tools
+check_command "ip"
+check_command "brctl"
+check_command "qemu-system-m68k"
+check_command "qemu-img"
+check_command "sudo"
+check_command "dd"
+
 # Check if a configuration file was specified
 if [ -z "$CONFIG_FILE" ]; then
     echo "Error: No configuration file specified. Use -C <config_file.conf>"
@@ -58,7 +188,7 @@ fi
 # Check if the configuration file exists and load it
 if [ -f "$CONFIG_FILE" ]; then
     echo "Loading configuration from: $CONFIG_FILE"
-    # Source the config file - variables defined here might override defaults above
+    # Source the config file - variables defined here override defaults
     source "$CONFIG_FILE"
 else
     echo "Error: Configuration file not found: $CONFIG_FILE"
@@ -66,12 +196,36 @@ else
 fi
 
 # Check if essential variables were loaded from config
-# Added QEMU_PRAM to the required list
-if [ -z "$QEMU_MACHINE" ] || [ -z "$QEMU_ROM" ] || [ -z "$QEMU_HDD" ] || [ -z "$QEMU_SHARED_HDD" ] || [ -z "$QEMU_RAM" ] || [ -z "$QEMU_GRAPHICS" ] || [ -z "$QEMU_PRAM" ]; then
+if [ -z "$QEMU_MACHINE" ] || [ -z "$QEMU_ROM" ] || [ -z "$QEMU_HDD" ] || [ -z "$QEMU_SHARED_HDD" ] || [ -z "$QEMU_RAM" ] || [ -z "$QEMU_GRAPHICS" ] || [ -z "$QEMU_PRAM" ] || [ -z "$BRIDGE_NAME" ]; then
      echo "Error: Config file $CONFIG_FILE is missing one or more required variables:"
      echo "Required: QEMU_MACHINE, QEMU_ROM, QEMU_HDD, QEMU_SHARED_HDD, QEMU_RAM, QEMU_GRAPHICS, QEMU_PRAM"
+     echo "Required (can use default): BRIDGE_NAME"
      exit 1
 fi
+
+# --- Dynamic Value Generation ---
+
+# Generate TAP device name if not specified in config
+if [ -z "$QEMU_TAP_IFACE" ]; then
+    # Sanitize config file name for use as part of tap name
+    SANITIZED_CONF_NAME=$(basename "$CONFIG_FILE" .conf | sed 's/[^a-zA-Z0-9]//g')
+    # Limit length to avoid exceeding interface name limits (IFNAMSIZ is often 16)
+    TAP_DEV_NAME="tap_${SANITIZED_CONF_NAME:0:10}"
+    echo "Info: QEMU_TAP_IFACE not set in config, generated TAP name: $TAP_DEV_NAME"
+else
+    TAP_DEV_NAME="$QEMU_TAP_IFACE"
+    echo "Info: Using TAP interface name from config: $TAP_DEV_NAME"
+fi
+
+# Generate MAC address if not specified
+if [ -z "$QEMU_MAC_ADDR" ]; then
+    MAC_ADDRESS=$(generate_mac)
+    echo "Info: QEMU_MAC_ADDR not set in config, generated MAC: $MAC_ADDRESS"
+else
+    MAC_ADDRESS="$QEMU_MAC_ADDR"
+    echo "Info: Using MAC address from config: $MAC_ADDRESS"
+fi
+
 
 # Set default shared HDD size if not specified in config
 DEFAULT_SHARED_HDD_SIZE="200M"
@@ -89,23 +243,16 @@ fi
 # --- File Preparation ---
 
 # Create PRAM image if it doesn't exist or is empty
-# Now uses QEMU_PRAM variable from config
 if [ ! -s "$QEMU_PRAM" ]; then
     PRAM_DIR=$(dirname "$QEMU_PRAM")
     if [ ! -d "$PRAM_DIR" ]; then
         echo "Creating directory for PRAM: $PRAM_DIR"
         mkdir -p "$PRAM_DIR"
-        if [ $? -ne 0 ]; then
-            echo "Error: Failed to create directory '$PRAM_DIR'."
-            exit 1
-        fi
+        if [ $? -ne 0 ]; then echo "Error: Failed to create directory '$PRAM_DIR'."; exit 1; fi
     fi
     echo "Creating new PRAM image file: $QEMU_PRAM"
-    dd if=/dev/zero of="$QEMU_PRAM" bs=256 count=1
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to create PRAM image '$QEMU_PRAM'."
-        exit 1
-    fi
+    dd if=/dev/zero of="$QEMU_PRAM" bs=256 count=1 status=none
+    if [ $? -ne 0 ]; then echo "Error: Failed to create PRAM image '$QEMU_PRAM'."; exit 1; fi
 fi
 
 # Create OS hard disk image if it doesn't exist
@@ -114,18 +261,12 @@ if [ ! -f "$QEMU_HDD" ]; then
     if [ ! -d "$HDD_DIR" ]; then
         echo "Creating directory for OS HDD: $HDD_DIR"
         mkdir -p "$HDD_DIR"
-        if [ $? -ne 0 ]; then
-            echo "Error: Failed to create directory '$HDD_DIR'."
-            exit 1
-        fi
+        if [ $? -ne 0 ]; then echo "Error: Failed to create directory '$HDD_DIR'."; exit 1; fi
     fi
     OS_DISK_SIZE=${QEMU_HDD_SIZE:-1G}
     echo "OS hard disk image '$QEMU_HDD' not found. Creating ($OS_DISK_SIZE)..."
-    qemu-img create -f raw "$QEMU_HDD" "$OS_DISK_SIZE"
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to create OS hard disk image '$QEMU_HDD'."
-        exit 1
-    fi
+    qemu-img create -f raw "$QEMU_HDD" "$OS_DISK_SIZE" > /dev/null
+    if [ $? -ne 0 ]; then echo "Error: Failed to create OS hard disk image '$QEMU_HDD'."; exit 1; fi
     echo "Empty OS hard disk image created. Proceeding with boot (likely from CD for install)."
 else
     echo "OS hard disk image '$QEMU_HDD' found."
@@ -137,17 +278,11 @@ if [ ! -f "$QEMU_SHARED_HDD" ]; then
     if [ ! -d "$SHARED_HDD_DIR" ]; then
         echo "Creating directory for Shared HDD: $SHARED_HDD_DIR"
         mkdir -p "$SHARED_HDD_DIR"
-        if [ $? -ne 0 ]; then
-            echo "Error: Failed to create directory '$SHARED_HDD_DIR'."
-            exit 1
-        fi
+        if [ $? -ne 0 ]; then echo "Error: Failed to create directory '$SHARED_HDD_DIR'."; exit 1; fi
     fi
     echo "Shared disk image '$QEMU_SHARED_HDD' not found. Creating ($QEMU_SHARED_HDD_SIZE)..."
-    qemu-img create -f raw "$QEMU_SHARED_HDD" "$QEMU_SHARED_HDD_SIZE"
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to create shared disk image '$QEMU_SHARED_HDD'."
-        exit 1
-    fi
+    qemu-img create -f raw "$QEMU_SHARED_HDD" "$QEMU_SHARED_HDD_SIZE" > /dev/null
+    if [ $? -ne 0 ]; then echo "Error: Failed to create shared disk image '$QEMU_SHARED_HDD'."; exit 1; fi
     echo "Empty shared disk image created. Format it within the emulator."
     echo "To share files with the VM (Linux example):"
     echo "  1. sudo mount -o loop \"$QEMU_SHARED_HDD\" /mnt"
@@ -156,14 +291,28 @@ if [ ! -f "$QEMU_SHARED_HDD" ]; then
 fi
 
 # --- Display Setup ---
-
+# Determine default display type if not forced by -d option
 if [ -z "$DISPLAY_TYPE" ]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        DISPLAY_TYPE="cocoa"
+        DISPLAY_TYPE="cocoa" # Cocoa is generally better on macOS
+        echo "Info: Detected macOS, using 'cocoa' display. Use -d to override."
     else
-        DISPLAY_TYPE="sdl" # Default to SDL
+        # Default to SDL on Linux/other systems
+        DISPLAY_TYPE="sdl"
+        echo "Info: Defaulting to 'sdl' display on this system. Use -d to override (e.g., -d gtk)."
     fi
 fi
+
+# --- Network Setup ---
+# Setup bridge first
+setup_bridge "$BRIDGE_NAME"
+
+# Setup TAP interface for this VM
+setup_tap "$TAP_DEV_NAME" "$BRIDGE_NAME"
+
+# Set trap to clean up TAP interface on exit
+# Pass TAP_DEV_NAME and BRIDGE_NAME correctly to the cleanup function
+trap "cleanup_tap '$TAP_DEV_NAME' '$BRIDGE_NAME'" EXIT SIGINT SIGTERM
 
 # --- QEMU Command Construction ---
 
@@ -172,11 +321,12 @@ echo "Configuration: $CONFIG_NAME"
 echo "Machine: $QEMU_MACHINE, RAM: ${QEMU_RAM}M, ROM: $QEMU_ROM"
 echo "OS HDD: $QEMU_HDD"
 echo "Shared HDD: $QEMU_SHARED_HDD"
-# Updated to show PRAM from config
 echo "PRAM: $QEMU_PRAM"
+echo "Network: TAP device '$TAP_DEV_NAME' on bridge '$BRIDGE_NAME', MAC: $MAC_ADDRESS"
 
 # Prepare the base command
-# Updated PRAM drive file to use QEMU_PRAM
+# Use TAP networking instead of -net user
+# Specify MAC address for the NIC using -net nic
 QEMU_CMD="qemu-system-m68k \
     -M \"$QEMU_MACHINE\" \
     -m \"$QEMU_RAM\" \
@@ -184,7 +334,8 @@ QEMU_CMD="qemu-system-m68k \
     -display \"$DISPLAY_TYPE\" \
     -g \"$QEMU_GRAPHICS\" \
     -drive file=\"$QEMU_PRAM\",format=raw,if=mtd \
-    -net nic,model=dp83932 -net user"
+    -netdev tap,id=net0,ifname=$TAP_DEV_NAME,script=no,downscript=no \
+    -net nic,netdev=net0,macaddr=$MAC_ADDRESS"
 
 # Add CPU if specified in config (optional)
 if [ -n "$QEMU_CPU" ]; then
@@ -194,7 +345,6 @@ fi
 # Add hard disks and CD-ROM with appropriate boot order
 if [ "$BOOT_FROM_CD" = true ] && [ -n "$CD_FILE" ]; then
     echo "Boot order: CD-ROM first ($CD_FILE)"
-    # *** MODIFIED VENDOR/PRODUCT STRINGS HERE ***
     QEMU_CMD="$QEMU_CMD \
     -device scsi-cd,scsi-id=0,drive=cd0 \
     -drive file=\"$CD_FILE\",format=raw,media=cdrom,if=none,id=cd0 \
@@ -204,15 +354,13 @@ if [ "$BOOT_FROM_CD" = true ] && [ -n "$CD_FILE" ]; then
     -drive file=\"$QEMU_SHARED_HDD\",media=disk,format=raw,if=none,id=hd1"
 else
     echo "Boot order: OS HDD first"
-    # Normal order - OS hard disk first (ID 0)
-    # *** MODIFIED VENDOR/PRODUCT STRINGS HERE ***
     QEMU_CMD="$QEMU_CMD \
     -device scsi-hd,scsi-id=0,drive=hd0,vendor=\"SEAGATE\",product=\"ST31200N\" \
     -drive file=\"$QEMU_HDD\",media=disk,format=raw,if=none,id=hd0 \
     -device scsi-hd,scsi-id=1,drive=hd1,vendor=\"SEAGATE\",product=\"ST3200N\" \
     -drive file=\"$QEMU_SHARED_HDD\",media=disk,format=raw,if=none,id=hd1"
 
-    # Add CD-ROM if specified (as ID 3)
+    # Add CD-ROM if specified (as SCSI ID 3)
     if [ -n "$CD_FILE" ]; then
         echo "CD-ROM: $CD_FILE (as SCSI ID 3)"
         QEMU_CMD="$QEMU_CMD \
@@ -232,16 +380,16 @@ echo "--------------------------"
 eval $QEMU_CMD
 
 # --- Error Handling ---
+# Note: Cleanup is handled by the trap
 exit_code=$?
 if [ $exit_code -ne 0 ]; then
     echo "QEMU exited with error code: $exit_code"
-    if [ "$DISPLAY_TYPE" = "sdl" ] && [[ "$OSTYPE" != "darwin"* ]]; then
-        echo "SDL display failed. You might try forcing GTK with: -d gtk"
-        echo "(Install GTK support if needed: sudo apt install libgtk-3-dev)"
-    fi
+    # Removed specific GTK/SDL failure messages as SDL is now default on Linux
+    # User can still force GTK with -d gtk if needed and available
     echo "Check QEMU output for specific error messages."
 else
     echo "QEMU session ended normally."
 fi
 
+# The trap will execute cleanup_tap here automatically
 exit $exit_code

--- a/sys710-q800.conf
+++ b/sys710-q800.conf
@@ -22,5 +22,10 @@ QEMU_PRAM="710/pram_710_q800.img"
 # Quadra 800 shipped with 7.1, can use its native resolution
 QEMU_GRAPHICS="1152x870x8"
 
+# --- Networking ---
+BRIDGE_NAME="br0"                 # Host bridge interface to connect to
+# QEMU_TAP_IFACE="tap_sys761"     # Optional: Specify a fixed TAP name (if commented out, script generates one like tap_sys761q800)
+# QEMU_MAC_ADDR="52:54:00:11:22:33" # Optional: Specify a fixed MAC address (if commented out, script generates one)
+
 # BE SURE TO INSTALL THE PPC UPGRADE VERSION OF SYSTEM 7.1 FROM APPLE LEGACY SOFTWARE RECOVERY DISC
 # NOT SURE WHY, BUT THATS WHAT WORKED FOR ME

--- a/sys755-q800.conf
+++ b/sys755-q800.conf
@@ -1,4 +1,4 @@
-# Configuration for System 7.5.5 on Quadra 800
+# Configuration for System 7.5.5 on Quadra 800 with TAP Networking
 
 CONFIG_NAME="System 7.5.5 (Quadra 800)"
 
@@ -10,9 +10,14 @@ QEMU_CPU=""               # Use default CPU for q800
 
 # --- Storage ---
 QEMU_HDD="755/hdd_sys755.img"             # Path to the main OS hard disk image
+QEMU_PRAM="755/pram_755_q800.img"         # Path to the PRAM image for this config
 QEMU_SHARED_HDD="755/shared_755.img"    # Path to the shared disk image for this config
-QEMU_PRAM="755/pram_755_q800.img"
-# QEMU_SHARED_HDD_SIZE="300M"   # Optional: uncomment and set size if not 200M
+# QEMU_SHARED_HDD_SIZE="300M"           # Optional: uncomment and set size if not using default (200M in script)
 
 # --- Graphics ---
 QEMU_GRAPHICS="1152x870x8" # Resolution and color depth
+
+# --- Networking ---
+BRIDGE_NAME="br0"                 # Host bridge interface to connect to (should match other VMs)
+# QEMU_TAP_IFACE="tap_sys755"     # Optional: Specify a fixed TAP name (if commented out, script generates one like tap_sys755q800)
+# QEMU_MAC_ADDR="52:54:00:AA:BB:CC" # Optional: Specify a fixed MAC address (if commented out, script generates one)

--- a/sys761-q800.conf
+++ b/sys761-q800.conf
@@ -1,10 +1,10 @@
-# Configuration for System 7.6.1 on Quadra 800
+# Configuration for System 7.6.1 on Quadra 800 with TAP Networking
 
 CONFIG_NAME="System 7.6.1 (Quadra 800)"
 
 # --- QEMU Machine Settings ---
 QEMU_MACHINE="q800"
-QEMU_RAM="256"            # RAM in MB (7.6.x can use this much)
+QEMU_RAM="256"            # RAM in MB
 QEMU_ROM="800.ROM"        # Path to the Quadra 800 ROM file
 QEMU_CPU=""               # Use default CPU for q800
 
@@ -16,3 +16,8 @@ QEMU_SHARED_HDD_SIZE="250M"       # Optional: Example of setting a specific size
 
 # --- Graphics ---
 QEMU_GRAPHICS="1152x870x8" # Resolution and color depth
+
+# --- Networking ---
+BRIDGE_NAME="br0"                 # Host bridge interface to connect to
+# QEMU_TAP_IFACE="tap_sys761"     # Optional: Specify a fixed TAP name (if commented out, script generates one like tap_sys761q800)
+# QEMU_MAC_ADDR="52:54:00:11:22:33" # Optional: Specify a fixed MAC address (if commented out, script generates one)


### PR DESCRIPTION
feat: Implement TAP networking and default to SDL display

This commit introduces significant changes to enable robust networking
between multiple QEMU Mac OS VMs and improves display compatibility.

Networking:
- Replaced basic '-net user' with TAP-based networking.
- Added functions to automatically create/manage a network bridge (default 'br0')
  and per-VM TAP interfaces using 'sudo ip', 'sudo brctl', and 'sudo ip tuntap'.
- Requires 'bridge-utils' package and sudo privileges.
- Implemented automatic cleanup of TAP interfaces on script exit using 'trap'.
- VMs now connect to the bridge, allowing direct communication (AppleTalk, TCP/IP).
- Updated config files to support network parameters (BRIDGE_NAME, etc.).
- Added dynamic generation of TAP interface names and MAC addresses.
- Fixed QEMU error by replacing specific '-device dp83932' with generic
  '-net nic,netdev=net0,macaddr=...' for broader compatibility.

Display:
- Changed the default display backend for Linux/non-macOS systems from
  attempting GTK first to defaulting directly to SDL ('-display sdl').
- This resolves mouse tracking issues (pointer unable to reach screen edges)
  observed when running multiple VMs with the GTK backend.
- The '-d' option can still be used to override the display backend
  (e.g., '-d gtk' or '-d cocoa').