### PR TITLE
feat: Add network mode selection (TAP/User) and refactor TAP logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 
 Introduction
 ------------
-This project provides a set of scripts to simplify the setup and management of classic Macintosh (m68k architecture) emulation using QEMU. It allows you to define different Mac OS configurations in separate files and easily launch them. Key features include automatic setup of bridged networking for inter-VM communication and a utility to share files between your host Linux system and the emulated Mac environment via a shared disk image.
+This project provides a set of scripts to simplify the setup and management of classic Macintosh (m68k architecture) emulation using QEMU. It allows you to define different Mac OS configurations in separate files and easily launch them. Key features include flexible networking options (bridged TAP for inter-VM communication or simple User Mode for internet access) and a utility to share files between your host Linux system and the emulated Mac environment via a shared disk image.
 
 Purpose
 -------
 - To provide a consistent and repeatable way to launch QEMU for specific Mac models and OS versions.
 - To manage separate disk images (OS, shared data, PRAM) for different configurations.
-- To automatically configure TAP networking, enabling direct communication (AppleTalk, TCP/IP) between multiple running VM instances.
+- To offer flexible networking:
+    - **TAP Mode (Default):** Automatically configures bridged TAP networking, enabling direct communication (AppleTalk, TCP/IP) between multiple running VM instances, but with no access to the internet.
+    - **User Mode:** Provides simple internet access for the VM via QEMU's built-in NAT, without requiring host network configuration or special privileges.
 - To simplify the process of booting from CD/ISO images for OS installation.
 - To offer a convenient method (`mac_disc_mounter.sh`) for accessing a shared disk image from the Linux host for file transfer.
 
@@ -17,19 +19,21 @@ Prerequisites
 -------------
 1.  **QEMU:** You need the `qemu-system-m68k` package installed.
     - On Debian/Ubuntu: `sudo apt update && sudo apt install qemu-system-m68k`
-2.  **Networking Utilities:** For the automatic network setup, you need `bridge-utils` and `iproute2` (usually installed by default).
+2.  **Networking Utilities (for TAP Mode):** If using the default TAP network mode (`-N tap`), you need `bridge-utils` and `iproute2` (usually installed by default).
     - On Debian/Ubuntu: `sudo apt update && sudo apt install bridge-utils`
-    - The script will check for `brctl` and prompt if `bridge-utils` is missing.
-3.  **Sudo Privileges:** The `run68k.sh` script now requires `sudo` privileges to create and manage the network bridge and TAP interfaces. You will likely be prompted for your password when launching a VM.
+    - The script will check for `brctl` and `ip` if TAP mode is selected and prompt if needed packages are missing.
+3.  **Sudo Privileges:** The `run68k.sh` script requires `sudo` privileges *when using the default TAP network mode* (`-N tap`) to create and manage the network bridge and TAP interfaces. You will likely be prompted for your password when launching a VM in TAP mode. User mode (`-N user`) does not require sudo for networking itself.
 4.  **Macintosh ROM Files:** You MUST obtain the correct ROM file(s) for the Macintosh model(s) you wish to emulate (e.g., `800.ROM` for a Quadra 800).
     - **IMPORTANT:** ROM files are copyrighted software and are NOT included with this project. You must acquire them legally (e.g., dump them from your own physical hardware). Place the ROM file(s) where the configuration files expect them (or update the paths in the `.conf` files). You can often find ROM files online. A common source is [Macintosh Repository](https://www.macintoshrepository.org/7038-all-macintosh-roms-68k-ppc-)
 5.  **Mac OS Installation Media:** You need CD-ROM images (.iso, .img, .toast) or floppy disk images for the version(s) of Mac OS you intend to install. These are also NOT included. I use the Apple Legacy Software Recovery CD from [Macintosh Garden](https://macintoshgarden.org/apps/apple-legacy-software-recovery-cd)
-6.  **Linux Host:** The `mac_disc_mounter.sh` script is specifically designed for Linux systems (using `apt` for package management and standard mount commands). The `run68k.sh` script is tested on Ubuntu but might work on other Unix-like systems (like macOS) with potential minor adjustments (e.g., display type, network setup commands).
+6.  **Linux Host:** The `mac_disc_mounter.sh` script is specifically designed for Linux systems (using `apt` for package management and standard mount commands). The `run68k.sh` script is tested on Ubuntu but might work on other Unix-like systems (like macOS) with potential minor adjustments (e.g., display type, network setup commands if using TAP).
 7.  **(For `mac_disc_mounter.sh`) HFS/HFS+ Utilities:** The mounting script requires `hfsprogs` and `hfsplus` to interact with Mac-formatted disk images. The script will attempt to install these automatically using `sudo apt-get install` if they are not found.
+8.  **TAP Functions Script (for TAP Mode):** The file `qemu-tap-functions.sh` must be present in the same directory as `run68k.sh` if you are using the default TAP network mode. It contains the necessary functions for setting up and tearing down TAP interfaces and bridges.
 
 File Structure
 --------------
-- `run68k.sh`: The main script to launch the QEMU emulator with network setup.
+- `run68k.sh`: The main script to launch the QEMU emulator.
+- `qemu-tap-functions.sh`: Contains helper functions for TAP networking setup/cleanup (used only when `-N tap` is active).
 - `mac_disc_mounter.sh`: Utility script to mount/unmount the shared disk image on the Linux host.
 - `*.conf`: Configuration files defining specific emulation setups (e.g., `sys755-q800.conf`).
 - `*.ROM`: (User-provided) Macintosh ROM files.
@@ -49,17 +53,16 @@ These files define the parameters for a specific emulation instance using shell 
 - `QEMU_HDD_SIZE`: (Optional) Size for the OS HDD if it needs to be created (default: 1G).
 - `QEMU_SHARED_HDD_SIZE`: (Optional) Size for the Shared HDD if it needs to be created (default: 200M).
 - `QEMU_CPU`: (Optional) Specify a specific CPU variant if needed.
-- `BRIDGE_NAME`: (Optional) Name of the host network bridge to use (default: `br0`).
-- `QEMU_TAP_IFACE`: (Optional) Specify a fixed name for the VM's TAP network interface. If omitted, a unique name is generated based on the config filename (e.g., `tap_sys755q800`).
-- `QEMU_MAC_ADDR`: (Optional) Specify a fixed MAC address for the VM's network interface. If omitted, a unique QEMU MAC address is generated.
+- **TAP Mode Specific (Optional):** These are only used if network mode is `tap`.
+    - `BRIDGE_NAME`: Name of the host network bridge to use (default: `br0`).
+    - `QEMU_TAP_IFACE`: Specify a fixed name for the VM's TAP network interface. If omitted, a unique name is generated based on the config filename (e.g., `tap_sys755q800`).
+    - `QEMU_MAC_ADDR`: Specify a fixed MAC address for the VM's network interface. If omitted, a unique QEMU MAC address is generated.
 
 You can create new `.conf` files for different Mac OS versions, machine types, or experimental setups. Ensure the paths point to unique locations if you want separate installations.
 
 Usage: `run68k.sh`
 -------------------
-This script launches the QEMU emulator based on a specified configuration file and sets up TAP networking.
-
-**IMPORTANT:** This script now requires `sudo` privileges to manage network interfaces.
+This script launches the QEMU emulator based on a specified configuration file and sets up networking according to the chosen mode.
 
 **Syntax:**
 `./run68k.sh -C <config_file.conf> [options]`
@@ -71,42 +74,59 @@ This script launches the QEMU emulator based on a specified configuration file a
 - `-c FILE`: Specify a CD-ROM image file (.iso, .img) to attach to the emulator. *Note this is little c not big C.*
 - `-b`: Boot from the attached CD-ROM (requires the `-c` option). Use this for OS installation.
 - `-d TYPE`: Force a specific QEMU display type (`sdl`, `gtk`, `cocoa`). If omitted, it attempts to auto-detect (cocoa for macOS, sdl for Linux/other).
+- `-N TYPE`: Specify network type:
+    - `tap` (Default): Use bridged TAP networking. Requires `sudo` and `qemu-tap-functions.sh`. Enables inter-VM communication but no internet access.
+    - `user`: Use QEMU User Mode networking. No `sudo` needed for networking, provides simple internet access (NAT), but no inter-VM communication.
 - `-?`: Show help message.
 
 **Examples:**
 
-1.  **Run an existing System 7.5.5 installation:**
+1.  **Run an existing System 7.5.5 installation (using default TAP networking):**
     `./run68k.sh -C sys755-q800.conf`
     *(You will likely be prompted for your sudo password for network setup)*
 
-2.  **Boot from a System 7.6.1 install CD to install the OS:**
+2.  **Run an existing System 7.5.5 installation with User Mode networking (for internet access):**
+    `./run68k.sh -C sys755-q800.conf -N user`
+    *(No sudo prompt for networking expected)*
+
+3.  **Boot from a System 7.6.1 install CD to install the OS (using default TAP networking):**
     `./run68k.sh -C sys761-q800.conf -c /path/to/your/Mac_OS_7.6.1.iso -b`
     *(will create `761/hdd_sys761.img`, `761/shared_761.img`, and `761/pram_761_q800.img` if they don't exist)*
     *You will need to use Drive Setup to format the disks on first boot before installing an OS*
 
-Networking Setup (Automatic)
-----------------------------
-The `run68k.sh` script now automatically configures networking to allow communication between multiple running VM instances.
+Networking Setup
+----------------
+The `run68k.sh` script configures networking based on the mode selected with the `-N` option.
 
-**How it Works:**
-1.  **Bridge Creation:** The script ensures a network bridge (default name `br0`, configurable via `BRIDGE_NAME` in `.conf`) exists on the host system. If not, it creates it using `sudo ip link`.
-2.  **TAP Interface Creation:** For each VM instance launched, the script creates a dedicated virtual network interface called a TAP device (e.g., `tap_sys755q800`) using `sudo ip tuntap`. This TAP device is owned by the user running the script.
-3.  **Connecting TAP to Bridge:** The script brings the TAP interface up and connects it to the network bridge using `sudo brctl addif`.
-4.  **QEMU Connection:** QEMU is configured to use this specific TAP device (`-netdev tap,... -net nic,...`) instead of the simpler (but isolated) `-net user`.
-5.  **Cleanup:** When the script exits (normally or via Ctrl+C), it automatically attempts to remove the TAP device from the bridge and delete the TAP device using `sudo`.
+**Why the Choice?**
+- **TAP Mode (`-N tap`, Default):** Best for running multiple VMs that need to communicate directly with each other (e.g., AppleTalk file sharing, network games). It simulates VMs being on the same physical network segment. However, it does *not* automatically grant the VMs internet access; that requires extra manual configuration on the host (bridging to a physical interface, NAT setup).
+- **User Mode (`-N user`):** Best for a single VM that needs simple access to the internet (if the host has it). QEMU handles NAT internally. It's simpler to set up (no `sudo`, no extra host config) but makes direct communication between VMs, or from the host to the VM, difficult.
 
-**Benefits:**
-- VMs connected to the same bridge can communicate directly using protocols like AppleTalk (for classic file sharing, printers) and TCP/IP (if configured).
-- This allows you to run multiple Mac OS VMs simultaneously and have them interact as if they were on the same physical Ethernet network.
-
-**In-VM Configuration:**
-- After launching the VM, you need to configure networking *inside* the emulated Mac OS:
-    - **Control Panels:** Use the `MacTCP` or `TCP/IP` (Open Transport) control panel.
+**TAP Mode (`-N tap`, Default) Details:**
+- **Requires:** `sudo`, `bridge-utils`, `iproute2`, `qemu-tap-functions.sh`.
+- **How it Works:**
+    1.  **Bridge Creation:** Ensures a network bridge (default `br0`) exists on the host (`sudo ip link`).
+    2.  **TAP Interface Creation:** Creates a dedicated TAP device (e.g., `tap_sys755q800`) for the VM (`sudo ip tuntap`).
+    3.  **Connecting TAP to Bridge:** Connects the TAP interface to the bridge (`sudo brctl addif`).
+    4.  **QEMU Connection:** QEMU uses this TAP device (`-netdev tap,... -net nic,...`).
+    5.  **Cleanup:** When the script exits, it automatically removes the TAP device from the bridge and deletes it (`sudo`).
+- **Benefits:** Direct VM-to-VM communication (AppleTalk, TCP/IP).
+- **Limitations:** No internet access for VMs.
+- **In-VM Configuration (TAP Mode):**
+    - **Control Panels:** Use `MacTCP` or `TCP/IP` (Open Transport).
     - **Connection Method:** Select `Ethernet`.
-    - **IP Address:** You can often use `DHCP` if you have a DHCP server running on your host or LAN accessible via the bridge. Otherwise, assign static IP addresses manually within the same subnet for each VM (e.g., `192.168.100.1`, `192.168.100.2`, with subnet mask `255.255.255.0`). Ensure these IPs don't conflict with other devices if your bridge is connected to your main LAN.
-    - **AppleTalk:** Use the `AppleTalk` control panel and ensure it's set to `Active` and connected via `Ethernet`. VMs on the same bridge should then see each other in the Chooser for file sharing.
+    - **IP Address:** Assign static IP addresses via DHCP.
+    - **AppleTalk:** Use the `AppleTalk` control panel (set to `Active`, via `Ethernet`). VMs on the same bridge should see each other in the Chooser.
 
-**Note:** This setup primarily enables VM-to-VM communication. Connecting VMs to your wider LAN or the internet requires additional host configuration (e.g., adding the host's physical interface to the bridge, setting up IP forwarding/NAT on the host) which is beyond the scope of this script's automatic setup.
+**User Mode (`-N user`) Details:**
+- **Requires:** None beyond QEMU itself.
+- **How it Works:** QEMU uses its internal network stack (`-net nic,model=dp83932 -net user`). It creates a virtual DHCP server and NAT router for the VM.
+- **Benefits:** Simple internet access for the VM (if host has it). No `sudo` needed for networking. No host network configuration.
+- **Limitations:** No easy direct communication between multiple VMs or from host to VM.
+- **In-VM Configuration (User Mode):**
+    - **Control Panels:** Use `MacTCP` or `TCP/IP`.
+    - **Connection Method:** Select `Ethernet`.
+    - **IP Address:** Configure using `DHCP Server`. QEMU will assign an IP (usually in the `10.0.2.x` range).
 
 Usage: `mac_disc_mounter.sh` (Linux Only)
 -----------------------------------------
@@ -148,38 +168,39 @@ This script mounts or unmounts the *shared* disk image associated with a specifi
 
 Getting Started / First OS Installation
 ---------------------------------------
-1.  **Install Prerequisites:** Ensure QEMU and `bridge-utils` are installed.
-2.  **Obtain ROM:** Get the correct ROM file (e.g., `800.ROM`) and place it where the `.conf` file expects it (e.g., in the same directory as the scripts, or update the `QEMU_ROM` path in the `.conf` file).
+1.  **Install Prerequisites:** Ensure QEMU is installed. If using TAP networking (default), install `bridge-utils` and ensure `qemu-tap-functions.sh` is present.
+2.  **Obtain ROM:** Get the correct ROM file and place it appropriately.
 3.  **Obtain Install Media:** Get the Mac OS install CD/ISO image.
-4.  **Choose Config:** Select a `.conf` file corresponding to the OS you want to install (e.g., `sys761-q800.conf`).
-5.  **Run Installer:** Execute `run68k.sh` with the `-c` (CD image) and `-b` (boot from CD) flags:
+4.  **Choose Config:** Select a `.conf` file.
+5.  **Run Installer:** Execute `run68k.sh` with the `-c` (CD image) and `-b` (boot from CD) flags. The default TAP networking is usually fine for installation.
     `./run68k.sh -C sys761-q800.conf -c /path/to/your/Mac_OS_7.6.1.iso -b`
-    *(The script will prompt for sudo password, create network interfaces, and create necessary directories/empty disk images if they don't exist)*
-6.  **Install OS:** Inside the QEMU window, follow the standard Mac OS installation procedure. You will need to initialize/format the virtual hard disk (`QEMU_HDD`) using a tool like "Drive Setup" or "Apple HD SC Setup" from the installer before you can install onto it.
-7.  **(Optional) Format Shared Disk:** While the installer is running (or after installation), you can also format the *shared* disk (`QEMU_SHARED_HDD`) using Drive Setup so it's ready for file transfer later. Format it as HFS or HFS+.
-8.  **Shutdown:** Once installation is complete, shut down the emulated Mac.
-9.  **First Boot from HDD:** Run the script *without* the `-c` and `-b` flags to boot from the newly installed OS on the virtual hard disk:
-    `./run68k.sh -C sys761-q800.conf`
-10. **Configure Networking (Inside VM):** Set up MacTCP/TCP/IP and AppleTalk control panels as described in the "Networking Setup" section if you want network connectivity.
-11. **File Transfer:**
-    - Shut down the emulated Mac.
-    - Mount the shared disk on your Linux host: `sudo ./mac_disc_mounter.sh -C sys761-q800.conf`
-    - Copy files to/from the mount point (e.g., `/mnt/mac_shared`).
-    - Unmount the disk: `sudo ./mac_disc_mounter.sh -C sys761-q800.conf -u`
-    - Start the emulator again: `./run68k.sh -C sys761-q800.conf`
+    *(If using TAP mode, the script will prompt for sudo password, create network interfaces, etc.)*
+6.  **Install OS:** Inside QEMU, initialize/format the virtual HDD (`QEMU_HDD`) using "Drive Setup" or similar, then install the OS.
+7.  **(Optional) Format Shared Disk:** Format the `QEMU_SHARED_HDD` as HFS/HFS+ using Drive Setup.
+8.  **Shutdown:** Shut down the emulated Mac.
+9.  **First Boot from HDD:** Run the script *without* `-c` and `-b`. Choose your network mode with `-N` if needed (default is TAP).
+    `./run68k.sh -C sys761-q800.conf` (Boots with TAP networking)
+    `./run68k.sh -C sys755-q800.conf` (Boots with TAP networking)
+
+OR
+    `./run68k.sh -C sys761-q800.conf -N user` (Boots with User networking)
+    `./run68k.sh -C sys755-q800.conf -N user` (Boots with User networking)
+10. **Configure Networking (Inside VM):** Set up MacTCP/TCP/IP and AppleTalk according to the network mode chosen (see "Networking Setup" section).
+11. **File Transfer:** Shut down VM, use `mac_disc_mounter.sh` to mount/unmount shared disk, copy files, restart VM.
 
 Important Notes
 ---------------
-- **ROM Legality:** Remember, you are responsible for legally obtaining any Macintosh ROM files.
-- **Permissions:** `run68k.sh` requires `sudo` for networking. `mac_disc_mounter.sh` also requires `sudo`. Ensure you have write permissions in the directories where disk images will be created by `run68k.sh`.
-- **Shared Disk Formatting:** The shared disk image needs to be formatted *inside* the emulated Mac OS before `mac_disc_mounter.sh` can successfully mount it for read/write access on the host.
-- **VM Shutdown:** Always shut down the QEMU virtual machine cleanly before attempting to mount its shared disk image on the host.
+- **ROM Legality:** You are responsible for legally obtaining Macintosh ROM files.
+- **Permissions:** `run68k.sh` requires `sudo` *when using TAP networking*. `mac_disc_mounter.sh` also requires `sudo`. Ensure write permissions for disk image directories.
+- **Shared Disk Formatting:** Format the shared disk *inside* the VM first.
+- **VM Shutdown:** Always shut down the VM before using `mac_disc_mounter.sh`.
 
 Troubleshooting
 ---------------
-- **"ROM file ... not found"**: Verify the `QEMU_ROM` path in your `.conf` file is correct and the ROM file exists at that location.
-- **"Failed to create directory/image"**: Check filesystem permissions for the directories specified in the `.conf` file paths (`QEMU_HDD`, `QEMU_SHARED_HDD`, `QEMU_PRAM`).
-- **Network Errors ("Failed to create bridge/TAP", "Failed to add TAP to bridge")**: Ensure `bridge-utils` is installed. Check `sudo` permissions. Make sure the bridge name (`br0`) or TAP name doesn't conflict with existing interfaces managed outside this script. Check system logs (`dmesg`, `journalctl`) for more details.
-- **VMs Cannot See Each Other:** Verify both VMs are running and connected to the *same* bridge (`br0` by default). Check the MacTCP/TCP/IP settings inside each VM (ensure they are on the same subnet if using static IPs). Check AppleTalk control panel settings (Ethernet, Active).
-- **QEMU display issues**: If the default display (`sdl` or `cocoa`) doesn't work well (e.g., mouse problems), try forcing another type with `-d gtk` (if available) or `-d sdl`. Ensure necessary host libraries (like SDL or GTK development headers) are installed.
-- **Cannot mount shared disk**: Ensure the VM is shut down. Ensure the disk was formatted inside the VM. Try the check (`-c`) or repair (`-r`) options with `mac_disc_mounter.sh`. Check system logs (`dmesg`) for mount errors.
+- **"ROM file ... not found"**: Verify `QEMU_ROM` path in `.conf`.
+- **"Failed to create directory/image"**: Check filesystem permissions.
+- **Network Errors (TAP Mode - "Failed to create bridge/TAP", etc.)**: Ensure `bridge-utils` installed. Check `sudo`. Check for interface name conflicts. Check system logs (`dmesg`, `journalctl`). Ensure `qemu-tap-functions.sh` exists.
+- **VMs Cannot See Each Other:** Ensure you are using TAP mode (`-N tap` or default). Verify both VMs are on the same bridge. Check in-VM IP/AppleTalk settings (see TAP Mode config details). This is expected behavior in User mode (`-N user`).
+- **No Internet Access:** This is expected in TAP mode (`-N tap`) without extra host configuration. If internet access is the priority, try User mode (`-N user`). Verify User mode in-VM config is set to DHCP.
+- **QEMU display issues**: Try forcing display type with `-d`. Ensure host libraries (SDL/GTK) are installed.
+- **Cannot mount shared disk**: Ensure VM is off. Ensure disk was formatted in VM. Try check (`-c`) or repair (`-r`) options. Check `dmesg`.

--- a/qemu-tap-functions.sh
+++ b/qemu-tap-functions.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# qemu-tap-functions.sh
+# Contains functions for setting up and tearing down TAP networking for QEMU VMs.
+# To be sourced by the main QEMU runner script.
+
+# Function to generate a random MAC address if not provided
+generate_mac() {
+    local hexchars="0123456789ABCDEF"
+    # QEMU MAC prefix 52:54:00
+    echo "52:54:00:$(for i in {1..6} ; do echo -n ${hexchars:$(( $RANDOM % 16 )):1} ; done | sed -e 's/\(..\)/\1:/g' -e 's/:$//')"
+}
+
+# Function to set up the network bridge
+# Takes bridge name as argument
+setup_bridge() {
+    local bridge="$1"
+    echo "--- Network Setup (TAP) ---"
+    echo "Ensuring bridge '$bridge' exists and is up..."
+    if ! ip link show "$bridge" &> /dev/null; then
+        echo "Bridge '$bridge' not found. Creating..."
+        sudo ip link add name "$bridge" type bridge
+        if [ $? -ne 0 ]; then echo "Error: Failed to create bridge '$bridge'."; exit 1; fi
+        echo "Bringing bridge '$bridge' up..."
+        sudo ip link set "$bridge" up
+        if [ $? -ne 0 ]; then echo "Error: Failed to bring up bridge '$bridge'."; exit 1; fi
+        echo "Bridge '$bridge' created and up."
+    else
+        # Ensure bridge is up even if it exists
+        if ! ip link show "$bridge" | grep -q "state UP"; then
+             echo "Bridge '$bridge' exists but is down. Bringing up..."
+             sudo ip link set "$bridge" up
+             if [ $? -ne 0 ]; then echo "Error: Failed to bring up bridge '$bridge'."; exit 1; fi
+        else
+             echo "Bridge '$bridge' already exists and is up."
+        fi
+    fi
+    echo "---------------------------"
+}
+
+# Function to set up the TAP interface for the VM
+# Takes TAP name, Bridge name, and User as arguments
+setup_tap() {
+    local tap_name="$1"
+    local bridge_name="$2"
+    local current_user="$3" # Pass user explicitly
+
+    echo "--- Network Setup (TAP) ---"
+    echo "Setting up TAP interface '$tap_name' for user '$current_user' on bridge '$bridge_name'..."
+
+    # Check if TAP device already exists (maybe from a crashed previous run)
+    if ip link show "$tap_name" &> /dev/null; then
+        echo "Warning: TAP device '$tap_name' already exists. Trying to reuse/reconfigure."
+        # Ensure it's down before potential deletion or reconfiguration
+        sudo ip link set "$tap_name" down &> /dev/null
+        # Attempt to remove from bridge just in case it's stuck
+        sudo brctl delif "$bridge_name" "$tap_name" &> /dev/null
+    fi
+
+    echo "Creating TAP device '$tap_name'..."
+    sudo ip tuntap add dev "$tap_name" mode tap user "$current_user"
+    if [ $? -ne 0 ]; then echo "Error: Failed to create TAP device '$tap_name'."; exit 1; fi
+
+    echo "Bringing TAP device '$tap_name' up..."
+    sudo ip link set "$tap_name" up
+    if [ $? -ne 0 ]; then echo "Error: Failed to bring up TAP device '$tap_name'."; sudo ip tuntap del dev "$tap_name" mode tap; exit 1; fi
+
+    echo "Adding TAP device '$tap_name' to bridge '$bridge_name'..."
+    sudo brctl addif "$bridge_name" "$tap_name"
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to add TAP device '$tap_name' to bridge '$bridge_name'."
+        sudo ip link set "$tap_name" down
+        sudo ip tuntap del dev "$tap_name" mode tap
+        exit 1
+    fi
+
+    echo "TAP device '$tap_name' is up and added to bridge '$bridge_name'."
+    echo "---------------------------"
+}
+
+# Function to clean up the TAP interface
+# Takes TAP name and Bridge name as arguments
+cleanup_tap() {
+    local tap_name="$1"
+    local bridge_name="$2"
+    echo # Newline for clarity after QEMU exits
+    echo "--- Network Cleanup (TAP) ---"
+    echo "Cleaning up TAP interface '$tap_name' from bridge '$bridge_name'..."
+
+    # Check if the interface exists before trying to manipulate it
+    if ip link show "$tap_name" &> /dev/null; then
+        echo "Removing TAP device '$tap_name' from bridge '$bridge_name'..."
+        sudo brctl delif "$bridge_name" "$tap_name"
+        # Don't exit on error here, proceed to bring down and delete
+
+        echo "Bringing TAP device '$tap_name' down..."
+        sudo ip link set "$tap_name" down
+
+        echo "Deleting TAP device '$tap_name'..."
+        sudo ip tuntap del dev "$tap_name" mode tap
+    else
+        echo "TAP device '$tap_name' not found, cleanup skipped."
+    fi
+    echo "---------------------------"
+}
+
+# --- TAP Specific Variable Generation ---
+# These functions might be called by the main script *if* TAP mode is selected
+# and config values are missing.
+
+# Function to generate TAP device name if not provided in config
+# Takes config file base name as argument
+generate_tap_name() {
+    local conf_base_name="$1"
+    # Sanitize config file name for use as part of tap name
+    local sanitized_name=$(echo "$conf_base_name" | sed 's/[^a-zA-Z0-9]//g')
+    # Limit length to avoid exceeding interface name limits (IFNAMSIZ is often 16)
+    echo "tap_${sanitized_name:0:10}"
+}
+
+# Note: generate_mac is already defined above

--- a/run68k.sh
+++ b/run68k.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Script to run Mac OS emulation using QEMU with configuration files
-# Updated to use TAP networking via a bridge for inter-VM communication
-# Defaults to SDL display on Linux/non-macOS systems
+# Supports both TAP/Bridge networking (default) and User Mode networking.
 
 # --- Configuration variables (will be loaded from .conf file) ---
 CONFIG_NAME=""
@@ -16,15 +15,19 @@ QEMU_GRAPHICS=""
 QEMU_CPU=""               # Optional CPU override
 QEMU_HDD_SIZE="1G"        # Default size for OS HDD if created
 QEMU_PRAM=""              # Path to the PRAM image file (now from config)
-BRIDGE_NAME="br0"         # Default bridge name (can be overridden in config)
-QEMU_TAP_IFACE=""         # Optional: Specific TAP interface name (generated if empty)
-QEMU_MAC_ADDR=""          # Optional: Specific MAC address (generated if empty)
+BRIDGE_NAME="br0"         # Default bridge name (used only if NETWORK_TYPE=tap)
+QEMU_TAP_IFACE=""         # Optional: Specific TAP interface name (used only if NETWORK_TYPE=tap)
+QEMU_MAC_ADDR=""          # Optional: Specific MAC address (used only if NETWORK_TYPE=tap)
 
 # --- Script variables ---
 CONFIG_FILE=""
 CD_FILE=""                # Path to CD/ISO image
 BOOT_FROM_CD=false
 DISPLAY_TYPE=""           # Auto-detect later if not specified
+NETWORK_TYPE="tap"        # Default network type ('tap' or 'user')
+TAP_FUNCTIONS_SCRIPT="./qemu-tap-functions.sh" # Path to TAP functions script
+
+# --- Variables used only in TAP mode ---
 TAP_DEV_NAME=""           # Actual TAP device name used for this instance
 MAC_ADDRESS=""            # Actual MAC address used
 
@@ -34,150 +37,79 @@ show_help() {
     echo "Required:"
     echo "  -C FILE  Specify configuration file (e.g., sys755-q800.conf)"
     echo "           The config file defines machine, RAM, ROM, disks, PRAM, graphics,"
-    echo "           and optionally BRIDGE_NAME, QEMU_TAP_IFACE, QEMU_MAC_ADDR."
+    echo "           and optionally BRIDGE_NAME, QEMU_TAP_IFACE, QEMU_MAC_ADDR (for TAP)."
     echo "Options:"
     echo "  -c FILE  Specify CD-ROM image file (if not specified, no CD will be attached)"
     echo "  -b       Boot from CD-ROM (requires -c option)"
     echo "  -d TYPE  Force display type (sdl, gtk, cocoa)"
+    echo "  -N TYPE  Specify network type: 'tap' (default, bridge-based) or 'user' (simple NAT)"
     echo "  -?       Show this help message"
-    echo "Networking:"
-    echo "  This script sets up TAP networking via a bridge (default: br0)."
-    echo "  Requires 'bridge-utils' package and sudo privileges."
+    echo "Networking Notes:"
+    echo "  'tap' mode (default): Uses TAP device on a bridge (default: br0)."
+    echo "     - Enables inter-VM communication on the same bridge."
+    echo "     - Requires '$TAP_FUNCTIONS_SCRIPT'."
+    echo "     - Requires 'bridge-utils', 'iproute2', and sudo privileges."
+    echo "     - Does NOT automatically provide internet access to VMs (requires extra host config)."
+    echo "  'user' mode: Uses QEMU's built-in User Mode Networking."
+    echo "     - Provides simple internet access via NAT (if host has it)."
+    echo "     - Does NOT easily allow inter-VM communication or host-to-VM connections."
+    echo "     - No special privileges or extra packages needed."
     exit 1
 }
 
-# --- Helper Functions ---
-
 # Function to check for required commands
+# Usage: check_command <command_name> [package_suggestion]
 check_command() {
     if ! command -v "$1" &> /dev/null; then
         echo "Error: Command '$1' not found."
-        if [ "$1" == "brctl" ]; then
-            echo "Please install 'bridge-utils': sudo apt update && sudo apt install bridge-utils"
+        if [ -n "$2" ]; then
+             echo "Please install it. Suggestion: $2"
         fi
-        exit 1
+        # Allow the main script to decide if this is fatal
+        return 1
     fi
-}
-
-# Function to generate a random MAC address if not provided
-generate_mac() {
-    hexchars="0123456789ABCDEF"
-    # QEMU MAC prefix 52:54:00
-    echo "52:54:00:$(for i in {1..6} ; do echo -n ${hexchars:$(( $RANDOM % 16 )):1} ; done | sed -e 's/\(..\)/\1:/g' -e 's/:$//')"
-}
-
-# Function to set up the network bridge
-setup_bridge() {
-    local bridge="$1"
-    echo "--- Network Setup ---"
-    echo "Ensuring bridge '$bridge' exists and is up..."
-    if ! ip link show "$bridge" &> /dev/null; then
-        echo "Bridge '$bridge' not found. Creating..."
-        sudo ip link add name "$bridge" type bridge
-        if [ $? -ne 0 ]; then echo "Error: Failed to create bridge '$bridge'."; exit 1; fi
-        echo "Bringing bridge '$bridge' up..."
-        sudo ip link set "$bridge" up
-        if [ $? -ne 0 ]; then echo "Error: Failed to bring up bridge '$bridge'."; exit 1; fi
-        echo "Bridge '$bridge' created and up."
-    else
-        # Ensure bridge is up even if it exists
-        if ! ip link show "$bridge" | grep -q "state UP"; then
-             echo "Bridge '$bridge' exists but is down. Bringing up..."
-             sudo ip link set "$bridge" up
-             if [ $? -ne 0 ]; then echo "Error: Failed to bring up bridge '$bridge'."; exit 1; fi
-        else
-             echo "Bridge '$bridge' already exists and is up."
-        fi
-    fi
-    echo "---------------------"
-}
-
-# Function to set up the TAP interface for the VM
-# Takes TAP name and Bridge name as arguments
-setup_tap() {
-    local tap_name="$1"
-    local bridge_name="$2"
-    local current_user=$(whoami)
-
-    echo "--- Network Setup ---"
-    echo "Setting up TAP interface '$tap_name' for user '$current_user'..."
-
-    # Check if TAP device already exists (maybe from a crashed previous run)
-    if ip link show "$tap_name" &> /dev/null; then
-        echo "Warning: TAP device '$tap_name' already exists. Trying to reuse/reconfigure."
-        # Ensure it's down before potential deletion or reconfiguration
-        sudo ip link set "$tap_name" down &> /dev/null
-        # Attempt to remove from bridge just in case it's stuck
-        sudo brctl delif "$bridge_name" "$tap_name" &> /dev/null
-    fi
-
-    echo "Creating TAP device '$tap_name'..."
-    sudo ip tuntap add dev "$tap_name" mode tap user "$current_user"
-    if [ $? -ne 0 ]; then echo "Error: Failed to create TAP device '$tap_name'."; exit 1; fi
-
-    echo "Bringing TAP device '$tap_name' up..."
-    sudo ip link set "$tap_name" up
-    if [ $? -ne 0 ]; then echo "Error: Failed to bring up TAP device '$tap_name'."; sudo ip tuntap del dev "$tap_name" mode tap; exit 1; fi
-
-    echo "Adding TAP device '$tap_name' to bridge '$bridge_name'..."
-    sudo brctl addif "$bridge_name" "$tap_name"
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to add TAP device '$tap_name' to bridge '$bridge_name'."
-        sudo ip link set "$tap_name" down
-        sudo ip tuntap del dev "$tap_name" mode tap
-        exit 1
-    fi
-
-    echo "TAP device '$tap_name' is up and added to bridge '$bridge_name'."
-    echo "---------------------"
-}
-
-# Function to clean up the TAP interface
-# Takes TAP name and Bridge name as arguments
-cleanup_tap() {
-    local tap_name="$1"
-    local bridge_name="$2"
-    echo # Newline for clarity after QEMU exits
-    echo "--- Network Cleanup ---"
-    echo "Cleaning up TAP interface '$tap_name'..."
-
-    # Check if the interface exists before trying to manipulate it
-    if ip link show "$tap_name" &> /dev/null; then
-        echo "Removing TAP device '$tap_name' from bridge '$bridge_name'..."
-        sudo brctl delif "$bridge_name" "$tap_name"
-        # Don't exit on error here, proceed to bring down and delete
-
-        echo "Bringing TAP device '$tap_name' down..."
-        sudo ip link set "$tap_name" down
-
-        echo "Deleting TAP device '$tap_name'..."
-        sudo ip tuntap del dev "$tap_name" mode tap
-    else
-        echo "TAP device '$tap_name' not found, cleanup skipped."
-    fi
-    echo "-----------------------"
+    return 0
 }
 
 # --- Argument Parsing ---
-while getopts "C:c:bd:?" opt; do
+while getopts "C:c:bd:N:?" opt; do
     case $opt in
         C) CONFIG_FILE="$OPTARG" ;;
         c) CD_FILE="$OPTARG" ;;
         b) BOOT_FROM_CD=true ;;
         d) DISPLAY_TYPE="$OPTARG" ;;
+        N) NETWORK_TYPE="$OPTARG" ;;
         \?|*) show_help ;;
     esac
 done
 
-# --- Validation and Configuration Loading ---
+# --- Validate Network Type ---
+if [[ "$NETWORK_TYPE" != "tap" && "$NETWORK_TYPE" != "user" ]]; then
+    echo "Error: Invalid network type specified with -N. Use 'tap' or 'user'."
+    show_help
+fi
 
-# Check required tools
-check_command "ip"
-check_command "brctl"
-check_command "qemu-system-m68k"
-check_command "qemu-img"
-check_command "sudo"
-check_command "dd"
+# --- Source TAP Functions if needed ---
+if [ "$NETWORK_TYPE" == "tap" ]; then
+    if [ -f "$TAP_FUNCTIONS_SCRIPT" ]; then
+        # Source the functions into the current script's environment
+        source "$TAP_FUNCTIONS_SCRIPT"
+        # Check for commands required ONLY for TAP mode
+        check_command "ip" "iproute2" || exit 1
+        check_command "brctl" "bridge-utils" || exit 1
+        check_command "sudo" "sudo" || exit 1
+    else
+        echo "Error: Network type 'tap' selected, but TAP functions script not found at: $TAP_FUNCTIONS_SCRIPT"
+        exit 1
+    fi
+fi
+
+# --- General Command Checks ---
+check_command "qemu-system-m68k" "qemu-system-m68k package" || exit 1
+check_command "qemu-img" "qemu-utils package" || exit 1
+check_command "dd" "coreutils package" || exit 1
+
+# --- Validation and Configuration Loading ---
 
 # Check if a configuration file was specified
 if [ -z "$CONFIG_FILE" ]; then
@@ -196,36 +128,46 @@ else
 fi
 
 # Check if essential variables were loaded from config
-if [ -z "$QEMU_MACHINE" ] || [ -z "$QEMU_ROM" ] || [ -z "$QEMU_HDD" ] || [ -z "$QEMU_SHARED_HDD" ] || [ -z "$QEMU_RAM" ] || [ -z "$QEMU_GRAPHICS" ] || [ -z "$QEMU_PRAM" ] || [ -z "$BRIDGE_NAME" ]; then
-     echo "Error: Config file $CONFIG_FILE is missing one or more required variables:"
-     echo "Required: QEMU_MACHINE, QEMU_ROM, QEMU_HDD, QEMU_SHARED_HDD, QEMU_RAM, QEMU_GRAPHICS, QEMU_PRAM"
-     echo "Required (can use default): BRIDGE_NAME"
-     exit 1
+# BRIDGE_NAME is only essential if using TAP mode
+REQ_VARS="QEMU_MACHINE QEMU_ROM QEMU_HDD QEMU_SHARED_HDD QEMU_RAM QEMU_GRAPHICS QEMU_PRAM"
+MISSING_VARS=false
+for var in $REQ_VARS; do
+    if [ -z "${!var}" ]; then # Use indirect expansion to check variable value
+        echo "Error: Config file $CONFIG_FILE is missing required variable: $var"
+        MISSING_VARS=true
+    fi
+done
+# Check BRIDGE_NAME only if TAP is selected
+if [ "$NETWORK_TYPE" == "tap" ] && [ -z "$BRIDGE_NAME" ]; then
+     echo "Error: Config file $CONFIG_FILE is missing required variable for TAP mode: BRIDGE_NAME (or default was empty)"
+     MISSING_VARS=true
+fi
+if [ "$MISSING_VARS" = true ]; then
+    exit 1
 fi
 
-# --- Dynamic Value Generation ---
 
-# Generate TAP device name if not specified in config
-if [ -z "$QEMU_TAP_IFACE" ]; then
-    # Sanitize config file name for use as part of tap name
-    SANITIZED_CONF_NAME=$(basename "$CONFIG_FILE" .conf | sed 's/[^a-zA-Z0-9]//g')
-    # Limit length to avoid exceeding interface name limits (IFNAMSIZ is often 16)
-    TAP_DEV_NAME="tap_${SANITIZED_CONF_NAME:0:10}"
-    echo "Info: QEMU_TAP_IFACE not set in config, generated TAP name: $TAP_DEV_NAME"
-else
-    TAP_DEV_NAME="$QEMU_TAP_IFACE"
-    echo "Info: Using TAP interface name from config: $TAP_DEV_NAME"
+# --- Dynamic Value Generation (TAP specific) ---
+if [ "$NETWORK_TYPE" == "tap" ]; then
+    # Generate TAP device name if not specified in config
+    if [ -z "$QEMU_TAP_IFACE" ]; then
+        CONFIG_BASENAME=$(basename "$CONFIG_FILE" .conf)
+        TAP_DEV_NAME=$(generate_tap_name "$CONFIG_BASENAME")
+        echo "Info: QEMU_TAP_IFACE not set in config, generated TAP name: $TAP_DEV_NAME"
+    else
+        TAP_DEV_NAME="$QEMU_TAP_IFACE"
+        echo "Info: Using TAP interface name from config: $TAP_DEV_NAME"
+    fi
+
+    # Generate MAC address if not specified
+    if [ -z "$QEMU_MAC_ADDR" ]; then
+        MAC_ADDRESS=$(generate_mac)
+        echo "Info: QEMU_MAC_ADDR not set in config, generated MAC: $MAC_ADDRESS"
+    else
+        MAC_ADDRESS="$QEMU_MAC_ADDR"
+        echo "Info: Using MAC address from config: $MAC_ADDRESS"
+    fi
 fi
-
-# Generate MAC address if not specified
-if [ -z "$QEMU_MAC_ADDR" ]; then
-    MAC_ADDRESS=$(generate_mac)
-    echo "Info: QEMU_MAC_ADDR not set in config, generated MAC: $MAC_ADDRESS"
-else
-    MAC_ADDRESS="$QEMU_MAC_ADDR"
-    echo "Info: Using MAC address from config: $MAC_ADDRESS"
-fi
-
 
 # Set default shared HDD size if not specified in config
 DEFAULT_SHARED_HDD_SIZE="200M"
@@ -303,16 +245,21 @@ if [ -z "$DISPLAY_TYPE" ]; then
     fi
 fi
 
-# --- Network Setup ---
-# Setup bridge first
-setup_bridge "$BRIDGE_NAME"
+# --- Network Setup (Conditional) ---
+if [ "$NETWORK_TYPE" == "tap" ]; then
+    # Setup bridge first
+    setup_bridge "$BRIDGE_NAME"
 
-# Setup TAP interface for this VM
-setup_tap "$TAP_DEV_NAME" "$BRIDGE_NAME"
+    # Setup TAP interface for this VM
+    setup_tap "$TAP_DEV_NAME" "$BRIDGE_NAME" "$(whoami)" # Pass current user
 
-# Set trap to clean up TAP interface on exit
-# Pass TAP_DEV_NAME and BRIDGE_NAME correctly to the cleanup function
-trap "cleanup_tap '$TAP_DEV_NAME' '$BRIDGE_NAME'" EXIT SIGINT SIGTERM
+    # Set trap to clean up TAP interface on exit
+    # Pass TAP_DEV_NAME and BRIDGE_NAME correctly to the cleanup function
+    trap "cleanup_tap '$TAP_DEV_NAME' '$BRIDGE_NAME'" EXIT SIGINT SIGTERM
+    echo "Info: TAP networking enabled. Cleanup trap set."
+else
+    echo "Info: User Mode networking enabled. No host-side setup or cleanup needed."
+fi
 
 # --- QEMU Command Construction ---
 
@@ -322,30 +269,37 @@ echo "Machine: $QEMU_MACHINE, RAM: ${QEMU_RAM}M, ROM: $QEMU_ROM"
 echo "OS HDD: $QEMU_HDD"
 echo "Shared HDD: $QEMU_SHARED_HDD"
 echo "PRAM: $QEMU_PRAM"
-echo "Network: TAP device '$TAP_DEV_NAME' on bridge '$BRIDGE_NAME', MAC: $MAC_ADDRESS"
 
-# Prepare the base command
-# Use TAP networking instead of -net user
-# Specify MAC address for the NIC using -net nic
-QEMU_CMD="qemu-system-m68k \
+# Prepare the base command (excluding network)
+QEMU_CMD_BASE="qemu-system-m68k \
     -M \"$QEMU_MACHINE\" \
     -m \"$QEMU_RAM\" \
     -bios \"$QEMU_ROM\" \
     -display \"$DISPLAY_TYPE\" \
     -g \"$QEMU_GRAPHICS\" \
-    -drive file=\"$QEMU_PRAM\",format=raw,if=mtd \
-    -netdev tap,id=net0,ifname=$TAP_DEV_NAME,script=no,downscript=no \
-    -net nic,netdev=net0,macaddr=$MAC_ADDRESS"
+    -drive file=\"$QEMU_PRAM\",format=raw,if=mtd"
 
 # Add CPU if specified in config (optional)
 if [ -n "$QEMU_CPU" ]; then
-    QEMU_CMD="$QEMU_CMD -cpu \"$QEMU_CPU\""
+    QEMU_CMD_BASE="$QEMU_CMD_BASE -cpu \"$QEMU_CPU\""
+fi
+
+# Construct Network Arguments based on type
+QEMU_NET_ARGS=""
+if [ "$NETWORK_TYPE" == "tap" ]; then
+    echo "Network: TAP device '$TAP_DEV_NAME' on bridge '$BRIDGE_NAME', MAC: $MAC_ADDRESS"
+    QEMU_NET_ARGS="-netdev tap,id=net0,ifname=$TAP_DEV_NAME,script=no,downscript=no -net nic,netdev=net0,macaddr=$MAC_ADDRESS"
+elif [ "$NETWORK_TYPE" == "user" ]; then
+    echo "Network: User Mode Networking"
+    # Use a common NIC model compatible with classic MacOS networking (e.g., OpenTransport)
+    QEMU_NET_ARGS="-net nic,model=dp83932 -net user"
 fi
 
 # Add hard disks and CD-ROM with appropriate boot order
+QEMU_DRIVE_ARGS=""
 if [ "$BOOT_FROM_CD" = true ] && [ -n "$CD_FILE" ]; then
     echo "Boot order: CD-ROM first ($CD_FILE)"
-    QEMU_CMD="$QEMU_CMD \
+    QEMU_DRIVE_ARGS="$QEMU_DRIVE_ARGS \
     -device scsi-cd,scsi-id=0,drive=cd0 \
     -drive file=\"$CD_FILE\",format=raw,media=cdrom,if=none,id=cd0 \
     -device scsi-hd,scsi-id=1,drive=hd0,vendor=\"SEAGATE\",product=\"ST31200N\" \
@@ -354,7 +308,7 @@ if [ "$BOOT_FROM_CD" = true ] && [ -n "$CD_FILE" ]; then
     -drive file=\"$QEMU_SHARED_HDD\",media=disk,format=raw,if=none,id=hd1"
 else
     echo "Boot order: OS HDD first"
-    QEMU_CMD="$QEMU_CMD \
+    QEMU_DRIVE_ARGS="$QEMU_DRIVE_ARGS \
     -device scsi-hd,scsi-id=0,drive=hd0,vendor=\"SEAGATE\",product=\"ST31200N\" \
     -drive file=\"$QEMU_HDD\",media=disk,format=raw,if=none,id=hd0 \
     -device scsi-hd,scsi-id=1,drive=hd1,vendor=\"SEAGATE\",product=\"ST3200N\" \
@@ -363,7 +317,7 @@ else
     # Add CD-ROM if specified (as SCSI ID 3)
     if [ -n "$CD_FILE" ]; then
         echo "CD-ROM: $CD_FILE (as SCSI ID 3)"
-        QEMU_CMD="$QEMU_CMD \
+        QEMU_DRIVE_ARGS="$QEMU_DRIVE_ARGS \
         -device scsi-cd,scsi-id=3,drive=cd0 \
         -drive file=\"$CD_FILE\",format=raw,media=cdrom,if=none,id=cd0"
     else
@@ -373,6 +327,10 @@ fi
 
 echo "Display: $DISPLAY_TYPE"
 echo "--------------------------"
+
+# Combine all parts of the command
+QEMU_CMD="$QEMU_CMD_BASE $QEMU_NET_ARGS $QEMU_DRIVE_ARGS"
+
 # Uncomment the next line if you want to see the full command before execution
 # echo "Executing: $QEMU_CMD"
 
@@ -380,16 +338,14 @@ echo "--------------------------"
 eval $QEMU_CMD
 
 # --- Error Handling ---
-# Note: Cleanup is handled by the trap
+# Note: Cleanup for TAP is handled by the trap
 exit_code=$?
 if [ $exit_code -ne 0 ]; then
     echo "QEMU exited with error code: $exit_code"
-    # Removed specific GTK/SDL failure messages as SDL is now default on Linux
-    # User can still force GTK with -d gtk if needed and available
     echo "Check QEMU output for specific error messages."
 else
     echo "QEMU session ended normally."
 fi
 
-# The trap will execute cleanup_tap here automatically
+# The trap (if set for TAP mode) will execute cleanup_tap here automatically
 exit $exit_code


### PR DESCRIPTION
Introduce a '-N' option to select network type:

  - 'tap' (default): Uses bridge/TAP for inter-VM communication.

  - 'user': Uses QEMU User Mode networking for simple internet access.

Refactor TAP-related functions (setup_bridge, setup_tap, cleanup_tap, helpers) into a separate 'qemu-tap-functions.sh' file, sourced conditionally when '-N tap' is active.

Define 'check_command' in the main script to ensure its availability for general checks regardless of the selected network mode, fixing a previous bug.