### PR TITLE
January 2025 improvements and .gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,12 @@ Mac OS 9.toast
 710
 755
 761
+
+# macOS system files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,12 @@ This project provides a modular set of shell scripts to simplify the setup and m
 
 ### Running Mac OS Emulation
 ```bash
-# Run existing Mac OS installation (TAP networking, default)
+# Run existing Mac OS installation (auto-detects networking: TAP on Linux, User on macOS)
 ./run68k.sh -C sys755-q800.conf
 
-# Run with User Mode networking (for internet access)  
-./run68k.sh -C sys755-q800.conf -N user
+# Run with specific networking mode
+./run68k.sh -C sys755-q800.conf -N user    # User Mode (internet access, macOS default)
+./run68k.sh -C sys755-q800.conf -N tap     # TAP Mode (VM-to-VM, Linux default)
 
 # Boot from CD/ISO for OS installation
 ./run68k.sh -C sys761-q800.conf -c /path/to/Mac_OS.iso -b
@@ -41,6 +42,17 @@ This project provides a modular set of shell scripts to simplify the setup and m
 
 # Enable debug mode with detailed logging
 ./run68k.sh -C sys755-q800.conf -D
+```
+
+### Platform-Specific Notes
+```bash
+# macOS (Apple Silicon/Intel) - requires modern bash and uses User Mode by default
+brew install qemu bash  # Install dependencies first
+./run68k.sh -C sys755-q800.conf  # Auto-uses User Mode networking
+
+# Linux - uses TAP networking by default
+sudo apt install qemu-system-m68k bridge-utils  # Install dependencies first  
+./run68k.sh -C sys755-q800.conf  # Auto-uses TAP networking
 ```
 
 ### File Sharing via Shared Disk
@@ -81,9 +93,13 @@ Each `.conf` file defines a complete Mac OS emulation setup with schema validati
 - `BRIDGE_NAME`, `QEMU_TAP_IFACE`, `QEMU_MAC_ADDR`, `QEMU_USER_SMB_DIR`
 
 ### Networking Modes
-- **TAP Mode (`-N tap`, default)**: Bridged networking for VM-to-VM communication, requires sudo
-- **User Mode (`-N user`)**: NAT networking for internet access, no sudo required
+- **TAP Mode (`-N tap`, Linux default)**: Bridged networking for VM-to-VM communication, requires sudo and Linux-specific tools
+- **User Mode (`-N user`, macOS default)**: NAT networking for internet access, no sudo required, works on all platforms
 - **Passt Mode (`-N passt`)**: Modern user-space networking (requires passt command)
+
+**Platform Defaults:**
+- **Linux**: TAP Mode (supports all networking tools)
+- **macOS**: User Mode (TAP requires Linux-specific iproute2/bridge-utils)
 
 ### File Structure Convention
 Config files create subdirectories containing:

--- a/README.md
+++ b/README.md
@@ -47,17 +47,18 @@ This project provides a robust framework for classic Mac emulation with modern c
 ✅ **Auto-Detection**: Smart defaults for display types and network interfaces  
 ✅ **Version Checking**: QEMU compatibility validation and warnings  
 ✅ **Package Management**: Automatic installation of required dependencies  
-✅ **Cross-Platform**: Designed for Linux, tested on Ubuntu, works on other Unix-like systems  
+✅ **Cross-Platform**: Designed for Linux, tested on Ubuntu, works on macOS (including Apple Silicon)  
 
 ## Quick Start
 
+### Linux (Ubuntu/Debian)
 ```bash
 # 1. Install QEMU
 sudo apt update && sudo apt install qemu-system-m68k bridge-utils
 
 # 2. Place your ROM file (e.g., 800.ROM) in the project directory
 
-# 3. Run a Mac OS installation
+# 3. Run a Mac OS installation (uses TAP networking by default)
 ./run68k.sh -C sys755-q800.conf -c /path/to/Mac_OS.iso -b
 
 # 4. After installation, run normally
@@ -67,31 +68,59 @@ sudo apt update && sudo apt install qemu-system-m68k bridge-utils
 sudo ./mac_disc_mounter.sh -C sys755-q800.conf
 ```
 
+### macOS (Intel/Apple Silicon)
+```bash
+# 1. Install QEMU and modern bash
+brew install qemu bash
+
+# 2. Place your ROM file (e.g., 800.ROM) in the project directory  
+
+# 3. Run a Mac OS installation (uses User Mode networking by default)
+./run68k.sh -C sys755-q800.conf -c /path/to/Mac_OS.iso -b
+
+# 4. After installation, run normally (auto-detects User Mode on macOS)
+./run68k.sh -C sys755-q800.conf
+
+# 5. Share files via shared disk (format as HFS/HFS+ in Mac OS first)
+# Files can be accessed directly from host at: ./761/shared_761.img
+```
+
 ## Prerequisites
 
 ### Required Software
 
 1. **QEMU (minimum version 4.0)**
    ```bash
-   # Debian/Ubuntu
+   # Linux (Debian/Ubuntu)
    sudo apt update && sudo apt install qemu-system-m68k qemu-utils
    
-   # Fedora/RHEL
+   # Linux (Fedora/RHEL)
    sudo dnf install qemu-system-m68k qemu-img
+   
+   # macOS (Homebrew)
+   brew install qemu
    ```
 
-2. **Networking Utilities (for TAP mode)**
+2. **Modern Bash (macOS only)**
    ```bash
-   # Debian/Ubuntu
+   # macOS ships with bash 3.2, but scripts require bash 4.0+ for associative arrays
+   brew install bash
+   ```
+
+3. **Networking Utilities (Linux TAP mode only)**
+   ```bash
+   # Linux (Debian/Ubuntu)
    sudo apt install bridge-utils iproute2
    
-   # Usually pre-installed, but required for TAP networking
+   # Note: TAP networking not available on macOS - uses User Mode automatically
    ```
 
-3. **HFS/HFS+ Tools (for file sharing)**
+4. **HFS/HFS+ Tools (Linux file sharing only)**
    ```bash
-   # Automatically installed by mac_disc_mounter.sh when needed
+   # Linux: Automatically installed by mac_disc_mounter.sh when needed
    sudo apt install hfsprogs hfsplus
+   
+   # macOS: Not needed - shared disk can be accessed directly as raw image
    ```
 
 ### Required Files (Not Included)
@@ -276,9 +305,10 @@ The primary script for launching Mac emulation with comprehensive options:
 
 The networking system supports three distinct modes, each optimized for different use cases:
 
-### TAP Mode (Default) - VM-to-VM Communication
+### TAP Mode (Linux Default) - VM-to-VM Communication
 
-**Best for**: Multiple VMs that need to communicate directly (AppleTalk, network games, file sharing)
+**Best for**: Multiple VMs that need to communicate directly (AppleTalk, network games, file sharing)  
+**Note**: Linux only - requires Linux-specific networking tools
 
 ```bash
 ./run68k.sh -C sys755-q800.conf -N tap
@@ -314,9 +344,10 @@ The networking system supports three distinct modes, each optimized for differen
 - ❌ Requires sudo privileges
 - ❌ More complex setup
 
-### User Mode - Internet Access
+### User Mode - Internet Access (macOS Default)
 
-**Best for**: Single VM that needs internet access, simple setups, no admin privileges
+**Best for**: Single VM that needs internet access, simple setups, no admin privileges  
+**Note**: Default on macOS where TAP mode requires Linux-specific tools
 
 ```bash
 ./run68k.sh -C sys755-q800.conf -N user

--- a/mac_disc_mounter.sh
+++ b/mac_disc_mounter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #######################################
 # Mac Disc Mounter Script

--- a/qemu-config.sh
+++ b/qemu-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #######################################
 # QEMU Configuration Management Module

--- a/qemu-display.sh
+++ b/qemu-display.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #######################################
 # QEMU Display Management Module

--- a/qemu-networking.sh
+++ b/qemu-networking.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #######################################
 # QEMU Networking Management Module

--- a/qemu-storage.sh
+++ b/qemu-storage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #######################################
 # QEMU Storage Management Module

--- a/qemu-tap-functions.sh
+++ b/qemu-tap-functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #######################################
 # QEMU TAP Networking Functions

--- a/qemu-utils.sh
+++ b/qemu-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #######################################
 # QEMU Mac Emulation Shared Utilities
@@ -484,7 +484,7 @@ check_qemu_version() {
         return 1
     fi
     
-    current_version=$(qemu-system-m68k --version | grep -oP 'version \K[0-9.]+' | head -n1)
+    current_version=$(qemu-system-m68k --version | sed -n 's/.*version \([0-9.]*\).*/\1/p' | head -n1)
     
     if [ -z "$current_version" ]; then
         warning_log "Could not determine QEMU version"

--- a/run68k.sh
+++ b/run68k.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #######################################
 # QEMU Mac OS Emulation Runner
@@ -48,7 +48,12 @@ CD_FILE=""
 ADDITIONAL_HDD_FILE=""
 BOOT_FROM_CD=false
 DISPLAY_TYPE=""
-NETWORK_TYPE="tap"
+# Auto-detect network type based on OS (TAP requires Linux, User mode for macOS)
+if [[ "$(uname)" == "Darwin" ]]; then
+    NETWORK_TYPE="user"  # Default to user mode on macOS (TAP requires Linux tools)
+else
+    NETWORK_TYPE="tap"   # Default to TAP on Linux
+fi
 DEBUG_MODE=false
 
 # --- Variables used only in TAP mode ---
@@ -78,20 +83,21 @@ show_help() {
     echo "  -a FILE  Specify an additional hard drive image file (e.g., mydrive.hda or mydrive.img)"
     echo "  -b       Boot from CD-ROM (requires -c option, modifies PRAM)"
     echo "  -d TYPE  Force display type (sdl, gtk, cocoa)"
-    echo "  -N TYPE  Specify network type: 'tap' (default), 'user' (NAT), or 'passt' (slirp alternative)"
+    echo "  -N TYPE  Specify network type: 'tap' (Linux default), 'user' (macOS default, NAT), or 'passt' (slirp alternative)"
     echo "  -D       Enable debug mode (set -x, show PRAM before launch)"
     echo "  -?       Show this help message"
     echo "Networking Notes:"
-    echo "  'tap' mode (default): Uses TAP device on a bridge (default: $DEFAULT_BRIDGE_NAME)."
+    echo "  'tap' mode (Linux default): Uses TAP device on a bridge (default: $DEFAULT_BRIDGE_NAME)."
     echo "     - Enables inter-VM communication on the same bridge."
     echo "     - Requires '$TAP_FUNCTIONS_SCRIPT'."
     echo "     - Requires 'bridge-utils', 'iproute2', and sudo privileges."
     echo "     - Does NOT automatically provide internet access to VMs (requires extra host config)."
-    echo "  'user' mode: Uses QEMU's built-in User Mode Networking."
+    echo "  'user' mode (macOS default): Uses QEMU's built-in User Mode Networking."
     echo "     - Provides simple internet access via NAT (if host has it)."
     echo "     - Can share a host directory via SMB using QEMU_USER_SMB_DIR in config."
     echo "     - Does NOT easily allow inter-VM communication or host-to-VM connections."
     echo "     - No special privileges or extra packages needed."
+    echo "     - Recommended for macOS as TAP mode requires Linux-specific tools."
     echo "  'passt' mode: Uses the passt userspace networking backend."
     echo "     - Alternative to 'user' mode, potentially better performance/features."
     echo "     - Requires the 'passt' command to be installed on the host (see https://passt.top/)."


### PR DESCRIPTION
## Summary
- Update .gitignore to properly exclude macOS system files (.DS_Store, etc.)
- Various improvements and refinements to the QEMU Mac emulation scripts
- Enhanced documentation and configuration management

## Test plan
- [ ] Verify .gitignore excludes .DS_Store files
- [ ] Test QEMU emulation functionality remains intact
- [ ] Validate script improvements work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)