### PR TITLE
Support Homebrew-installed BASH shell.

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # QemuMac Dependency Installer - Installs QEMU and required dependencies
 # Supports both macOS and Ubuntu/Debian Linux

--- a/iso-downloader.sh
+++ b/iso-downloader.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # QemuMac Asset Downloader - A simple script to download software and ROMs.
 #

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # QemuMac Common Library - Shared utilities for all QemuMac scripts
 #

--- a/mount-shared.sh
+++ b/mount-shared.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # QemuMac Shared Disk Mounter - Simple script to mount the shared disk
 #

--- a/run-mac.sh
+++ b/run-mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Euo pipefail
 source "$(dirname "$0")/lib/common.sh"
 


### PR DESCRIPTION
This change prevents an error arising from the use of the default, system-provided BASH installation which exhibits itself as an empty selection menu:

```
~/Projects/QemuMac$ ./iso-downloader.sh

--- Select a Category ---
./iso-downloader.sh: line 31: mapfile: command not found
1) 
2) Quit
Choose a category: 1
```

After correction, the menu appears:

```
~/Projects/QemuMac$ ./iso-downloader.sh

--- Select a Category ---
1) Games
2) Operating Systems
3) ROMs
4) Utilities
5) Quit
Choose a category: 5
Info: Exiting
```

On modern systems, this may require declaration as a dependency.

(Apologies for the EOF stripping of an extraneous newline character… my Vim setup may be a bit overzealous.)